### PR TITLE
Pass factory to define()

### DIFF
--- a/query-string.js
+++ b/query-string.js
@@ -57,7 +57,7 @@
 	};
 
 	if (typeof define === 'function' && define.amd) {
-		define([], queryString);
+		define(function() { return queryString; });
 	} else if (typeof module !== 'undefined' && module.exports) {
 		module.exports = queryString;
 	} else {


### PR DESCRIPTION
This fixes the AMD export which is currently passing an object (instead of a factory to `define()`).
