### PR TITLE
Remove ampersand

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,10 +5,10 @@ exports.parse = function (str) {
 		return {};
 	}
 
-	if (str[0] == '&') {
+	if (str[0] === '&') {
 		str = str.substr(1, str.length);
 	}
-	
+
 	str = str.trim().replace(/^(\?|#)/, '');
 
 	if (!str) {

--- a/index.js
+++ b/index.js
@@ -11,6 +11,10 @@ exports.parse = function (str) {
 		return {};
 	}
 
+	if (str[0] == '&') {
+		str = str.substr(1, str.length);
+	}
+
 	return str.trim().split('&').reduce(function (ret, param) {
 		var parts = param.replace(/\+/g, ' ').split('=');
 		var key = parts[0];

--- a/index.js
+++ b/index.js
@@ -5,11 +5,7 @@ exports.parse = function (str) {
 		return {};
 	}
 
-	if (str[0] === '&') {
-		str = str.substr(1, str.length);
-	}
-
-	str = str.trim().replace(/^(\?|#)/, '');
+	str = str.trim().replace(/^(\?|#|&)/, '');
 
 	if (!str) {
 		return {};

--- a/index.js
+++ b/index.js
@@ -5,14 +5,14 @@ exports.parse = function (str) {
 		return {};
 	}
 
+	if (str[0] == '&') {
+		str = str.substr(1, str.length);
+	}
+	
 	str = str.trim().replace(/^(\?|#)/, '');
 
 	if (!str) {
 		return {};
-	}
-
-	if (str[0] == '&') {
-		str = str.substr(1, str.length);
 	}
 
 	return str.trim().split('&').reduce(function (ret, param) {

--- a/test.js
+++ b/test.js
@@ -11,7 +11,7 @@ describe('.parse()', function () {
 		assert.deepEqual(qs.parse('#foo=bar'), {foo: 'bar'});
 	});
 
-	it('remove & from starts', function () {
+	it('query strings starting with a `&', function () {
 		assert.deepEqual(qs.parse('&foo=bar&foo=baz'), {foo: ['bar', 'baz']});
 	});
 

--- a/test.js
+++ b/test.js
@@ -38,6 +38,10 @@ describe('.parse()', function () {
 	it('handle multiple of the same key', function () {
 		assert.deepEqual(qs.parse('foo=bar&foo=baz'), {foo: ['bar', 'baz']});
 	});
+
+	it('remove & from starts', function () {
+		assert.deepEqual(qs.parse('&foo=bar&foo=baz'), {foo: ['bar', 'baz']});
+	});
 });
 
 describe('.stringify()', function () {

--- a/test.js
+++ b/test.js
@@ -31,6 +31,7 @@ describe('.parse()', function () {
 
 	it('return empty object if no qss can be found', function () {
 		assert.deepEqual(qs.parse('?'), {});
+		assert.deepEqual(qs.parse('&'), {});
 		assert.deepEqual(qs.parse('#'), {});
 		assert.deepEqual(qs.parse(' '), {});
 	});

--- a/test.js
+++ b/test.js
@@ -11,6 +11,10 @@ describe('.parse()', function () {
 		assert.deepEqual(qs.parse('#foo=bar'), {foo: 'bar'});
 	});
 
+	it('remove & from starts', function () {
+		assert.deepEqual(qs.parse('&foo=bar&foo=baz'), {foo: ['bar', 'baz']});
+	});
+
 	it('parse a query string', function () {
 		assert.deepEqual(qs.parse('foo=bar'), {foo: 'bar'});
 	});
@@ -37,10 +41,6 @@ describe('.parse()', function () {
 
 	it('handle multiple of the same key', function () {
 		assert.deepEqual(qs.parse('foo=bar&foo=baz'), {foo: ['bar', 'baz']});
-	});
-
-	it('remove & from starts', function () {
-		assert.deepEqual(qs.parse('&foo=bar&foo=baz'), {foo: ['bar', 'baz']});
 	});
 });
 


### PR DESCRIPTION
Hi!
If query string starts with &, result from parse will be { '': null, data: 'item' }
```javascript
console.log(query.parse("&data=item")); //{ '': null, data: 'item' }
```
So, I've just a made more predictable behavior.
```javascript
console.log(query.parse("&data=item")); //{ data: 'item' }
```