### PR TITLE
ensure correct parsing the query params with '='

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ exports.parse = function (str) {
 	return str.trim().split('&').reduce(function (ret, param) {
 		var parts = param.replace(/\+/g, ' ').split('=');
 		var key = parts[0];
-		var val = parts[1];
+		var val = parts.slice(1).join('=');
 
 		key = decodeURIComponent(key);
 		// missing `=` should be `null`:


### PR DESCRIPTION
Expected:
http://someurl/?param=http%3A%2F%2Fsomeurl%3Fid%3D2837
should be parsed to:
{ param: 'http://someurl?id=2837' }
actual:
{ param: 'http://someurl?id' }

This change fixes that issue.