### PR TITLE
add getQueryString method fixes #15

### DIFF
--- a/query-string.js
+++ b/query-string.js
@@ -7,7 +7,19 @@
 */
 (function () {
 	'use strict';
+
 	var queryString = {};
+
+	queryString.getQueryString = function (maybeUrl) {
+		if(!maybeUrl) {
+			return;
+		}
+
+		var pos = maybeUrl.indexOf('?');
+		if(pos > -1) {
+			return maybeUrl.substring(pos + 1);
+		}
+	};
 
 	queryString.parse = function (str) {
 		if (typeof str !== 'string') {

--- a/test.js
+++ b/test.js
@@ -59,3 +59,22 @@ describe('.stringify()', function () {
 		assert.strictEqual(qs.stringify({abc: 'abc', foo: ['bar', 'baz']}), 'abc=abc&foo=bar&foo=baz');
 	});
 });
+
+
+describe('.getQueryString()', function () {
+	it('should extract qs from url', function () {
+		assert.equal(qs.getQueryString("http://foo.bar/?abc=def&hij=klm"), "abc=def&hij=klm");
+		assert.equal(qs.getQueryString("http://foo.bar/?"), "");
+	});
+
+	it('should handle urls without qs', function () {
+		assert.equal(qs.getQueryString("http://foo.bar/"), null);
+	});
+
+	it('should handle bad input', function () {
+		assert.equal(qs.getQueryString(""), null);
+		assert.equal(qs.getQueryString(undefined), null);
+		assert.equal(qs.getQueryString(null), null);
+	});
+
+});


### PR DESCRIPTION
Adds a convenience method `getQueryString` to extract query string from a full URL