### PR TITLE
Filter empty strings before ampersand concatenation

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,5 +50,7 @@ exports.stringify = function (obj) {
 		}
 
 		return strictUriEncode(key) + '=' + strictUriEncode(val);
+	}).filter(function(x) {
+		return x.length > 0;
 	}).join('&') : '';
 };


### PR DESCRIPTION
Addresses #31 by filtering out* empty strings that result from empty arrays. Passes @tusharmath's test case. Can't at the moment think of obvious corner cases since everything inside returns a string so that `.length` should be safe.

`*` trying hard not to get off-topic on the naming of `Array.prototype.filter` which confuses me every time