### PR TITLE
Make tests compatible with latest version of AVA

### DIFF
--- a/test/extract.js
+++ b/test/extract.js
@@ -4,17 +4,14 @@ import fn from '../';
 test('should extract query string from url', t => {
 	t.is(fn.extract('http://foo.bar/?abc=def&hij=klm'), 'abc=def&hij=klm');
 	t.is(fn.extract('http://foo.bar/?'), '');
-	t.end();
 });
 
 test('should handle strings not containing query string', t => {
 	t.is(fn.extract('http://foo.bar/'), '');
 	t.is(fn.extract(''), '');
-	t.end();
 });
 
 test('should throw for invalid values', t => {
 	t.throws(fn.extract.bind(fn, null), TypeError);
 	t.throws(fn.extract.bind(fn, undefined), TypeError);
-	t.end();
 });

--- a/test/parse.js
+++ b/test/parse.js
@@ -3,34 +3,28 @@ import fn from '../';
 
 test('query strings starting with a `?`', t => {
 	t.same(fn.parse('?foo=bar'), {foo: 'bar'});
-	t.end();
 });
 
 test('query strings starting with a `#`', t => {
 	t.same(fn.parse('#foo=bar'), {foo: 'bar'});
-	t.end();
 });
 
 test('query strings starting with a `&`', t => {
 	t.same(fn.parse('&foo=bar&foo=baz'), {foo: ['bar', 'baz']});
-	t.end();
 });
 
 test('parse a query string', t => {
 	t.same(fn.parse('foo=bar'), {foo: 'bar'});
-	t.end();
 });
 
 test('parse multiple query string', t => {
 	t.same(fn.parse('foo=bar&key=val'), {foo: 'bar', key: 'val'});
-	t.end();
 });
 
 test('parse query string without a value', t => {
 	t.same(fn.parse('foo'), {foo: null});
 	t.same(fn.parse('foo&key'), {foo: null, key: null});
 	t.same(fn.parse('foo=bar&key'), {foo: 'bar', key: null});
-	t.end();
 });
 
 test('return empty object if no qss can be found', t => {
@@ -38,25 +32,20 @@ test('return empty object if no qss can be found', t => {
 	t.same(fn.parse('&'), {});
 	t.same(fn.parse('#'), {});
 	t.same(fn.parse(' '), {});
-	t.end();
 });
 
 test('handle `+` correctly', t => {
 	t.same(fn.parse('foo+faz=bar+baz++'), {'foo faz': 'bar baz  '});
-	t.end();
 });
 
 test('handle multiple of the same key', t => {
 	t.same(fn.parse('foo=bar&foo=baz'), {foo: ['bar', 'baz']});
-	t.end();
 });
 
 test('query strings params including embedded `=`', t => {
 	t.same(fn.parse('?param=http%3A%2F%2Fsomeurl%3Fid%3D2837'), {param: 'http://someurl?id=2837'});
-	t.end();
 });
 
 test('query strings params including raw `=`', t => {
 	t.same(fn.parse('?param=http://someurl?id=2837'), {param: 'http://someurl?id=2837'});
-	t.end();
 });

--- a/test/stringify.js
+++ b/test/stringify.js
@@ -4,37 +4,30 @@ import fn from '../';
 test('stringify', t => {
 	t.same(fn.stringify({foo: 'bar'}), 'foo=bar');
 	t.same(fn.stringify({foo: 'bar', bar: 'baz'}), 'bar=baz&foo=bar');
-	t.end();
 });
 
 test('different types', t => {
 	t.same(fn.stringify(), '');
 	t.same(fn.stringify(0), '');
-	t.end();
 });
 
 test('URI encode', t => {
 	t.same(fn.stringify({'foo bar': 'baz faz'}), 'foo%20bar=baz%20faz');
 	t.same(fn.stringify({'foo bar': 'baz\'faz'}), 'foo%20bar=baz%27faz');
-	t.end();
 });
 
 test('handle array value', t => {
 	t.same(fn.stringify({abc: 'abc', foo: ['bar', 'baz']}), 'abc=abc&foo=bar&foo=baz');
-	t.end();
 });
 
 test('handle empty array value', t => {
 	t.same(fn.stringify({abc: 'abc', foo: []}), 'abc=abc');
-	t.end();
 });
 
 test('should not encode undefined values', t => {
 	t.same(fn.stringify({abc: undefined, foo: 'baz'}), 'foo=baz');
-	t.end();
 });
 
 test('should encode null values as just a key', t => {
 	t.same(fn.stringify({xyz: null, abc: null, foo: 'baz'}), 'abc&foo=baz&xyz');
-	t.end();
 });


### PR DESCRIPTION
Tests were throwing the 't.end is not supported in this context.' with
latest version of AVA so I removed all the t.end() calls since it seems
to no longer be necessary. May also want to consider specifying a version for AVA
in package.json.