### PR TITLE
support object properties

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ exports.parse = function (str) {
 		// http://w3.org/TR/2012/WD-url-20120524/#collect-url-parameters
 		val = val === undefined ? null : decodeURIComponent(val);
 
-		if (!ret.hasOwnProperty(key)) {
+		if (!ret[key]) {
 			ret[key] = val;
 		} else if (Array.isArray(ret[key])) {
 			ret[key].push(val);
@@ -38,7 +38,7 @@ exports.parse = function (str) {
 		}
 
 		return ret;
-	}, {});
+	}, Object.create(null));
 };
 
 exports.stringify = function (obj) {

--- a/test/parse.js
+++ b/test/parse.js
@@ -1,51 +1,67 @@
 import test from 'ava';
 import fn from '../';
 
+// https://github.com/sindresorhus/query-string/pull/48#issuecomment-198242935
+function tsame(t, actual, expected) {
+	Object.keys(expected).forEach(key => {
+		t.is(actual[key], expected[key]);
+	});
+}
+
+test.beforeEach(t => {
+	t.context.same = tsame.bind(undefined, t);
+});
+
 test('query strings starting with a `?`', t => {
-	t.same(fn.parse('?foo=bar'), {foo: 'bar'});
+	t.context.same(fn.parse('?foo=bar'), {foo: 'bar'});
 });
 
 test('query strings starting with a `#`', t => {
-	t.same(fn.parse('#foo=bar'), {foo: 'bar'});
+	t.context.same(fn.parse('#foo=bar'), {foo: 'bar'});
 });
 
 test('query strings starting with a `&`', t => {
-	t.same(fn.parse('&foo=bar&foo=baz'), {foo: ['bar', 'baz']});
+	t.context.same(fn.parse('&foo=bar&foo=baz'), {foo: ['bar', 'baz']});
 });
 
 test('parse a query string', t => {
-	t.same(fn.parse('foo=bar'), {foo: 'bar'});
+	t.context.same(fn.parse('foo=bar'), {foo: 'bar'});
 });
 
 test('parse multiple query string', t => {
-	t.same(fn.parse('foo=bar&key=val'), {foo: 'bar', key: 'val'});
+	t.context.same(fn.parse('foo=bar&key=val'), {foo: 'bar', key: 'val'});
 });
 
 test('parse query string without a value', t => {
-	t.same(fn.parse('foo'), {foo: null});
-	t.same(fn.parse('foo&key'), {foo: null, key: null});
-	t.same(fn.parse('foo=bar&key'), {foo: 'bar', key: null});
+	t.context.same(fn.parse('foo'), {foo: null});
+	t.context.same(fn.parse('foo&key'), {foo: null, key: null});
+	t.context.same(fn.parse('foo=bar&key'), {foo: 'bar', key: null});
 });
 
 test('return empty object if no qss can be found', t => {
-	t.same(fn.parse('?'), {});
-	t.same(fn.parse('&'), {});
-	t.same(fn.parse('#'), {});
-	t.same(fn.parse(' '), {});
+	t.context.same(fn.parse('?'), {});
+	t.context.same(fn.parse('&'), {});
+	t.context.same(fn.parse('#'), {});
+	t.context.same(fn.parse(' '), {});
 });
 
 test('handle `+` correctly', t => {
-	t.same(fn.parse('foo+faz=bar+baz++'), {'foo faz': 'bar baz  '});
+	t.context.same(fn.parse('foo+faz=bar+baz++'), {'foo faz': 'bar baz  '});
 });
 
 test('handle multiple of the same key', t => {
-	t.same(fn.parse('foo=bar&foo=baz'), {foo: ['bar', 'baz']});
+	t.context.same(fn.parse('foo=bar&foo=baz'), {foo: ['bar', 'baz']});
 });
 
 test('query strings params including embedded `=`', t => {
-	t.same(fn.parse('?param=http%3A%2F%2Fsomeurl%3Fid%3D2837'), {param: 'http://someurl?id=2837'});
+	t.context.same(fn.parse('?param=http%3A%2F%2Fsomeurl%3Fid%3D2837'), {param: 'http://someurl?id=2837'});
 });
 
 test('query strings params including raw `=`', t => {
-	t.same(fn.parse('?param=http://someurl?id=2837'), {param: 'http://someurl?id=2837'});
+	t.context.same(fn.parse('?param=http://someurl?id=2837'), {param: 'http://someurl?id=2837'});
+});
+
+test('object methods', t => {
+	t.context.same(fn.parse('hasOwnProperty=foo'), {hasOwnProperty: 'fo'});
+	t.context.same(fn.parse('__proto__=bar'), {__proto__: 'bar'});
 });


### PR DESCRIPTION
I'm not 100% sure if this is the correct solution for #47, but just gave it a go.

The tests fail although every result is correct. Because the prototype of the object is set to null, `t.same` does not validate correctly. Not sure how to resolve this.

-

Fixes #47.