### PR TITLE
handle `null` and `undefined` in array - fixes #49

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,9 +54,21 @@ exports.stringify = function (obj) {
 		}
 
 		if (Array.isArray(val)) {
-			return val.slice().sort().map(function (val2) {
-				return strictUriEncode(key) + '=' + strictUriEncode(val2);
-			}).join('&');
+			var result = [];
+
+			val.slice().sort().forEach(function (val2) {
+				if (val2 === undefined) {
+					return;
+				}
+
+				if (val2 === null) {
+					result.push(strictUriEncode(key));
+				} else {
+					result.push(strictUriEncode(key) + '=' + strictUriEncode(val2));
+				}
+			});
+
+			return result.join('&');
 		}
 
 		return strictUriEncode(key) + '=' + strictUriEncode(val);

--- a/test/stringify.js
+++ b/test/stringify.js
@@ -31,3 +31,15 @@ test('should not encode undefined values', t => {
 test('should encode null values as just a key', t => {
 	t.same(fn.stringify({xyz: null, abc: null, foo: 'baz'}), 'abc&foo=baz&xyz');
 });
+
+test('handle null values in array', t => {
+	t.same(fn.stringify({foo: null, bar: [null, 'baz']}), 'bar=baz&bar&foo');
+});
+
+test('handle undefined values in array', t => {
+	t.same(fn.stringify({foo: null, bar: [undefined, 'baz']}), 'bar=baz&foo');
+});
+
+test('handle undefined and null values in array', t => {
+	t.same(fn.stringify({foo: null, bar: [undefined, null, 'baz']}), 'bar=baz&bar&foo');
+});


### PR DESCRIPTION
This PR fixes #49.

@sindresorhus I know you are not a big fan of `Array.prototype.reduce`, so I used a simple `forEach` instead (which actually looks cleaner as well).