### PR TITLE
Add 'lowercaseHex' option to stringify()

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,8 +41,12 @@ exports.parse = function (str) {
 	}, {});
 };
 
-exports.stringify = function (obj) {
-	return obj ? Object.keys(obj).sort().map(function (key) {
+var hexRegex = /%[0-9A-F]{2}/g;
+
+exports.stringify = function (obj, options) {
+	options = options || {};
+
+	var queryString = obj ? Object.keys(obj).sort().map(function (key) {
 		var val = obj[key];
 
 		if (val === undefined) {
@@ -75,4 +79,12 @@ exports.stringify = function (obj) {
 	}).filter(function (x) {
 		return x.length > 0;
 	}).join('&') : '';
+
+	if (options.lowercaseHex === true) {
+		return queryString.replace(hexRegex, function (hex) {
+			return hex.toLowerCase();
+		});
+	}
+
+	return queryString;
 };

--- a/readme.md
+++ b/readme.md
@@ -30,12 +30,17 @@ console.log(parsedHash);
 //=> {token: 'bada55cafe'}
 
 parsed.foo = 'unicorn';
-parsed.ilike = 'pizza';
+parsed.ilike = 'pizza+coke';
 
 location.search = queryString.stringify(parsed);
 
 console.log(location.search);
-//=> '?foo=unicorn&ilike=pizza'
+//=> '?foo=unicorn&ilike=pizza%2Bcoke'
+
+location.search = queryString.stringify(parsed, { lowercaseHex: true });
+
+console.log(location.search);
+//=> '?foo=unicorn&ilike=pizza%2bcoke'
 ```
 
 
@@ -45,9 +50,11 @@ console.log(location.search);
 
 Parse a query string into an object. Leading `?` or `#` are ignored, so you can pass `location.search` or `location.hash` directly.
 
-### .stringify(*object*)
+### .stringify(*object*[, *options*])
 
 Stringify an object into a query string, sorting the keys.
+
+By default, URL encoded characters will be uppercase. Set `options.lowercaseHex` to `true` to make them lowercase.
 
 ### .extract(*string*)
 

--- a/test/stringify.js
+++ b/test/stringify.js
@@ -14,6 +14,11 @@ test('different types', t => {
 test('URI encode', t => {
 	t.same(fn.stringify({'foo bar': 'baz faz'}), 'foo%20bar=baz%20faz');
 	t.same(fn.stringify({'foo bar': 'baz\'faz'}), 'foo%20bar=baz%27faz');
+	t.same(fn.stringify({'foo bar': 'baz/faz'}), 'foo%20bar=baz%2Ffaz');
+});
+
+test('lowercaseHex', t => {
+	t.same(fn.stringify({'foo bar': 'Baz/faz'}, {lowercaseHex: true}), 'foo%20bar=Baz%2ffaz');
 });
 
 test('handle array value', t => {


### PR DESCRIPTION
Sometimes, when building URLs, you need to be able to control the casing of the query string, including the URL encoded hex codes (e.g. `%2f` vs `%2F`). This is important for SEO reasons.

By default, `stringify()` returns uppercase hex codes. This PR adds a `lowercaseHex` option to lowercase them.