### PR TITLE
handle possible error of decodeURIComponent method

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,6 +10,14 @@ function encode(value, opts) {
 	return value;
 }
 
+function decode(value) {
+	try {
+		return decodeURIComponent(value);
+	} catch (err) {
+		return value;
+	}
+}
+
 exports.extract = function (str) {
 	return str.split('?')[1] || '';
 };
@@ -36,11 +44,11 @@ exports.parse = function (str) {
 		var key = parts.shift();
 		var val = parts.length > 0 ? parts.join('=') : undefined;
 
-		key = decodeURIComponent(key);
+		key = decode(key);
 
 		// missing `=` should be `null`:
 		// http://w3.org/TR/2012/WD-url-20120524/#collect-url-parameters
-		val = val === undefined ? null : decodeURIComponent(val);
+		val = val === undefined ? null : decode(val);
 
 		if (ret[key] === undefined) {
 			ret[key] = val;

--- a/test/parse.js
+++ b/test/parse.js
@@ -56,3 +56,7 @@ test('object properties', t => {
 	t.falsy(fn.parse().prototype);
 	t.deepEqual(fn.parse('hasOwnProperty=foo'), {hasOwnProperty: 'foo'});
 });
+
+test('handle decodeURIComponent error correctly', t => {
+	t.deepEqual(fn.parse('?param=%'), {param: '%'});
+});


### PR DESCRIPTION
Hi,

JS builtin method `decodeURIComponent` will throw an error if a value could not be decoded.
```
> decodeURIComponent('param=%')
Uncaught URIError: URI malformed(…)
```
In this PR a function `decode` was added to handle this error.