### PR TITLE
Specify main entry of the project

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "engines": {
     "node": ">=0.10.0"
   },
+  "main": "index.js",
   "scripts": {
     "test": "xo && ava"
   },


### PR DESCRIPTION
This is required (at least) when using WebJars and `webjar-locator` to build the RequireJS configuration for this project.