### PR TITLE
Incorrect handling of arrays

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,7 +36,8 @@ exports.parse = function (str) {
 		var key = parts.shift();
 		var val = parts.length > 0 ? parts.join('=') : undefined;
 
-		key = decodeURIComponent(key);
+		key = decodeURIComponent(key)
+			.replace(/\[\]$/,"");
 
 		// missing `=` should be `null`:
 		// http://w3.org/TR/2012/WD-url-20120524/#collect-url-parameters
@@ -80,11 +81,12 @@ exports.stringify = function (obj, opts) {
 				if (val2 === undefined) {
 					return;
 				}
+				var arrayKey = encode(key, encode) + '[]';
 
 				if (val2 === null) {
-					result.push(encode(key, opts));
+					result.push(arrayKey);
 				} else {
-					result.push(encode(key, opts) + '=' + encode(val2, opts));
+					result.push(arrayKey + '=' + encode(val2, opts));
 				}
 			});
 

--- a/index.js
+++ b/index.js
@@ -37,7 +37,7 @@ exports.parse = function (str) {
 		var val = parts.length > 0 ? parts.join('=') : undefined;
 
 		key = decodeURIComponent(key)
-			.replace(/\[\]$/,"");
+			.replace(/\[\]$/, '');
 
 		// missing `=` should be `null`:
 		// http://w3.org/TR/2012/WD-url-20120524/#collect-url-parameters

--- a/readme.md
+++ b/readme.md
@@ -97,7 +97,7 @@ queryString.parse('likes=cake&name=bob&likes=icecream');
 //=> {likes: ['cake', 'icecream'], name: 'bob'}
 
 queryString.stringify({color: ['taupe', 'chartreuse'], id: '515'});
-//=> 'color=chartreuse&color=taupe&id=515'
+//=> 'color[]=chartreuse&color[]=taupe&id=515'
 ```
 
 

--- a/test/parse.js
+++ b/test/parse.js
@@ -10,7 +10,7 @@ test('query strings starting with a `#`', t => {
 });
 
 test('query strings starting with a `&`', t => {
-	t.deepEqual(fn.parse('&foo=bar&foo=baz'), {foo: ['bar', 'baz']});
+	t.deepEqual(fn.parse('&foo[]=bar&foo[]=baz'), {foo: ['bar', 'baz']});
 });
 
 test('parse a query string', t => {
@@ -34,8 +34,8 @@ test('parse query string without a value', t => {
 		foo: 'bar',
 		key: null
 	});
-	t.deepEqual(fn.parse('a&a'), {a: [null, null]});
-	t.deepEqual(fn.parse('a=&a'), {a: ['', null]});
+	t.deepEqual(fn.parse('a[]&a[]'), {a: [null, null]});
+	t.deepEqual(fn.parse('a[]=&a[]'), {a: ['', null]});
 });
 
 test('return empty object if no qss can be found', t => {
@@ -50,7 +50,7 @@ test('handle `+` correctly', t => {
 });
 
 test('handle multiple of the same key', t => {
-	t.deepEqual(fn.parse('foo=bar&foo=baz'), {foo: ['bar', 'baz']});
+	t.deepEqual(fn.parse('foo[]=bar&foo[]=baz'), {foo: ['bar', 'baz']});
 });
 
 test('query strings params including embedded `=`', t => {

--- a/test/stringify.js
+++ b/test/stringify.js
@@ -27,14 +27,14 @@ test('handle array value', t => {
 	t.is(fn.stringify({
 		abc: 'abc',
 		foo: ['bar', 'baz']
-	}), 'abc=abc&foo=bar&foo=baz');
+	}), 'abc=abc&foo[]=bar&foo[]=baz');
 });
 
 test('array order', t => {
 	t.is(fn.stringify({
 		abc: 'abc',
 		foo: ['baz', 'bar']
-	}), 'abc=abc&foo=baz&foo=bar');
+	}), 'abc=abc&foo[]=baz&foo[]=bar');
 });
 
 test('handle empty array value', t => {
@@ -63,29 +63,29 @@ test('handle null values in array', t => {
 	t.is(fn.stringify({
 		foo: null,
 		bar: [null, 'baz']
-	}), 'bar&bar=baz&foo');
+	}), 'bar[]&bar[]=baz&foo');
 });
 
 test('handle undefined values in array', t => {
 	t.is(fn.stringify({
 		foo: null,
 		bar: [undefined, 'baz']
-	}), 'bar=baz&foo');
+	}), 'bar[]=baz&foo');
 });
 
 test('handle undefined and null values in array', t => {
 	t.is(fn.stringify({
 		foo: null,
 		bar: [undefined, null, 'baz']
-	}), 'bar&bar=baz&foo');
+	}), 'bar[]&bar[]=baz&foo');
 });
 
 test('strict encoding', t => {
 	t.is(fn.stringify({foo: '\'bar\''}), 'foo=%27bar%27');
-	t.is(fn.stringify({foo: ['\'bar\'', '!baz']}), 'foo=%27bar%27&foo=%21baz');
+	t.is(fn.stringify({foo: ['\'bar\'', '!baz']}), 'foo[]=%27bar%27&foo[]=%21baz');
 });
 
 test('loose encoding', t => {
 	t.is(fn.stringify({foo: '\'bar\''}, {strict: false}), 'foo=\'bar\'');
-	t.is(fn.stringify({foo: ['\'bar\'', '!baz']}, {strict: false}), 'foo=\'bar\'&foo=!baz');
+	t.is(fn.stringify({foo: ['\'bar\'', '!baz']}, {strict: false}), 'foo[]=\'bar\'&foo[]=!baz');
 });


### PR DESCRIPTION
Add square brackets for array items of stringified query string. Remove square brackets while parsing query string with array items. Updated tests and readme. Also related ti [issue#66](https://github.com/sindresorhus/query-string/issues/66).