### PR TITLE
Support ordering by allowing array of object to be passed to stringif…

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,7 +62,19 @@ exports.stringify = function (obj, opts) {
 
 	opts = objectAssign(defaults, opts);
 
-	return obj ? Object.keys(obj).sort().map(function (key) {
+	if (!obj) {
+		return '';
+	} else if (Array.isArray(obj)) {
+		return obj.map(function (obj) {
+			return stringifyObject(obj, opts);
+		}).join('&');
+	}
+
+	return stringifyObject(obj, opts);
+};
+
+function stringifyObject(obj, opts) {
+	return Object.keys(obj).sort().map(function (key) {
 		var val = obj[key];
 
 		if (val === undefined) {
@@ -94,5 +106,5 @@ exports.stringify = function (obj, opts) {
 		return encode(key, opts) + '=' + encode(val, opts);
 	}).filter(function (x) {
 		return x.length > 0;
-	}).join('&') : '';
-};
+	}).join('&');
+}

--- a/readme.md
+++ b/readme.md
@@ -74,6 +74,20 @@ Default: `true`
 Extract a query string from a URL that can be passed into `.parse()`.
 
 
+## Ordering
+
+Ordering is supported by passing array of objects in format `[{key1: 'value1', key2: 'value2']`
+
+```js
+queryString.stringify([
+	{x: 'y'},
+	{a: 'b'},
+	{y: 'z'}
+]);
+//=> 'x=y&a=b&y=z'
+```
+
+
 ## Nesting
 
 This module intentionally doesn't support nesting as it's not spec'd and varies between implementations, which causes a lot of [edge cases](https://github.com/visionmedia/node-querystring/issues).

--- a/test/stringify.js
+++ b/test/stringify.js
@@ -89,3 +89,16 @@ test('loose encoding', t => {
 	t.is(fn.stringify({foo: '\'bar\''}, {strict: false}), 'foo=\'bar\'');
 	t.is(fn.stringify({foo: ['\'bar\'', '!baz']}, {strict: false}), 'foo=\'bar\'&foo=!baz');
 });
+
+test('array of objects order', t => {
+	t.is(fn.stringify([
+		{a: 'b'},
+		{x: 'y'},
+		{y: 'z'}
+	]), 'a=b&x=y&y=z');
+	t.is(fn.stringify([
+		{x: 'y'},
+		{a: 'b'},
+		{y: 'z'}
+	]), 'x=y&a=b&y=z');
+});


### PR DESCRIPTION
Support ordering by allowing array of object to be passed to stringify. Still using same stringify implementation. Test added and documentation updated.
Original stringify function is extracted to stringifyObject function. This way I was able to use it without any changes to it.