### PR TITLE
Added option `sortKeys` as a control to avoid sorting the keys

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,42 +57,49 @@ exports.parse = function (str) {
 exports.stringify = function (obj, opts) {
 	var defaults = {
 		encode: true,
+		sortKeys: true,
 		strict: true
 	};
 
 	opts = objectAssign(defaults, opts);
 
-	return obj ? Object.keys(obj).sort().map(function (key) {
-		var val = obj[key];
+	if (obj) {
+		var keys = Object.keys(obj);
+		keys = opts.sortKeys ? keys.sort() : keys;
+		return keys.map(function (key) {
+			var val = obj[key];
 
-		if (val === undefined) {
-			return '';
-		}
+			if (val === undefined) {
+				return '';
+			}
 
-		if (val === null) {
-			return encode(key, opts);
-		}
+			if (val === null) {
+				return encode(key, opts);
+			}
 
-		if (Array.isArray(val)) {
-			var result = [];
+			if (Array.isArray(val)) {
+				var result = [];
 
-			val.slice().forEach(function (val2) {
-				if (val2 === undefined) {
-					return;
-				}
+				val.slice().forEach(function (val2) {
+					if (val2 === undefined) {
+						return;
+					}
 
-				if (val2 === null) {
-					result.push(encode(key, opts));
-				} else {
-					result.push(encode(key, opts) + '=' + encode(val2, opts));
-				}
-			});
+					if (val2 === null) {
+						result.push(encode(key, opts));
+					} else {
+						result.push(encode(key, opts) + '=' + encode(val2, opts));
+					}
+				});
 
-			return result.join('&');
-		}
+				return result.join('&');
+			}
 
-		return encode(key, opts) + '=' + encode(val, opts);
-	}).filter(function (x) {
-		return x.length > 0;
-	}).join('&') : '';
+			return encode(key, opts) + '=' + encode(val, opts);
+		}).filter(function (x) {
+			return x.length > 0;
+		}).join('&');
+	}
+
+	return '';
 };

--- a/readme.md
+++ b/readme.md
@@ -58,7 +58,7 @@ The returned object is created with [`Object.create(null)`](https://developer.mo
 
 ### .stringify(*object*, *[options]*)
 
-Stringify an object into a query string, sorting the keys.
+Stringify an object into a query string, sorting the keys by default.
 
 #### strict
 
@@ -74,6 +74,13 @@ Type: `boolean`<br>
 Default: `true`
 
 [URL encode](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent) the keys and values.
+
+#### sortKeys
+
+Type: `boolean`<br>
+Default: `true`
+
+Set to `false` to avoid sorting the keys.
 
 ### .extract(*string*)
 

--- a/test/stringify.js
+++ b/test/stringify.js
@@ -23,6 +23,13 @@ test('no encoding', t => {
 	t.is(fn.stringify({'foo:bar': 'baz:faz'}, {encode: false}), 'foo:bar=baz:faz');
 });
 
+test('no sorting', t => {
+	t.is(fn.stringify({
+		xyz: 'xyz',
+		abc: 'abc'
+	}, {sortKeys: false}), 'xyz=xyz&abc=abc');
+});
+
 test('handle array value', t => {
 	t.is(fn.stringify({
 		abc: 'abc',
@@ -54,8 +61,8 @@ test('should not encode undefined values', t => {
 test('should encode null values as just a key', t => {
 	t.is(fn.stringify({
 		'x y z': null,
-		'abc': null,
-		'foo': 'baz'
+		abc: null,
+		foo: 'baz'
 	}), 'abc&foo=baz&x%20y%20z');
 });
 


### PR DESCRIPTION
Defaults to `true`, every other test case remains intact

```js
import { stringify } from 'query-string';
stringify({
  xyz: 'xyz',
  abc: 'abc'
}, {sortKeys: false}))  // 'xyz=xyz&abc=abc' 
```