### PR TITLE
Preserve appearance order while handling multiple values

### DIFF
--- a/index.js
+++ b/index.js
@@ -150,7 +150,7 @@ exports.parse = function (str, opts) {
 	return Object.keys(ret).sort().reduce(function (result, key) {
 		var val = ret[key];
 		if (Boolean(val) && typeof val === 'object' && !Array.isArray(val)) {
-			// We need to sort keys in object, not values
+			// Sort object keys, not values
 			result[key] = keysSorter(val);
 		} else {
 			result[key] = val;

--- a/index.js
+++ b/index.js
@@ -96,11 +96,11 @@ function encode(value, opts) {
 	return value;
 }
 
-function sorter(input) {
+function keysSorter(input) {
 	if (Array.isArray(input)) {
 		return input.sort();
 	} else if (typeof input === 'object') {
-		return sorter(Object.keys(input)).sort(function (a, b) {
+		return keysSorter(Object.keys(input)).sort(function (a, b) {
 			return Number(a) - Number(b);
 		}).map(function (key) {
 			return input[key];
@@ -148,10 +148,12 @@ exports.parse = function (str, opts) {
 	});
 
 	return Object.keys(ret).sort().reduce(function (result, key) {
-		if (Boolean(ret[key]) && typeof ret[key] === 'object') {
-			result[key] = sorter(ret[key]);
+		var val = ret[key];
+		if (Boolean(val) && typeof val === 'object' && !Array.isArray(val)) {
+			// We need to sort keys in object, not values
+			result[key] = keysSorter(val);
 		} else {
-			result[key] = ret[key];
+			result[key] = val;
 		}
 
 		return result;

--- a/test/parse.js
+++ b/test/parse.js
@@ -53,6 +53,21 @@ test('handle multiple of the same key', t => {
 	t.deepEqual(fn.parse('foo=bar&foo=baz'), {foo: ['bar', 'baz']});
 });
 
+test('handle multiple values and preserve appearence order', t => {
+	t.deepEqual(fn.parse('a=value&a='), {a: ['value', '']});
+	t.deepEqual(fn.parse('a=&a=value'), {a: ['', 'value']});
+});
+
+test('handle multiple values and preserve appearance order with brackets', t => {
+	t.deepEqual(fn.parse('a[]=value&a[]=', {arrayFormat: 'bracket'}), {a: ['value', '']});
+	t.deepEqual(fn.parse('a[]=&a[]=value', {arrayFormat: 'bracket'}), {a: ['', 'value']});
+});
+
+test('handle multiple values and preserve appearance order with indexes', t => {
+	t.deepEqual(fn.parse('a[0]=value&a[1]=', {arrayFormat: 'index'}), {a: ['value', '']});
+	t.deepEqual(fn.parse('a[1]=&a[0]=value', {arrayFormat: 'index'}), {a: ['value', '']});
+});
+
 test('query strings params including embedded `=`', t => {
 	t.deepEqual(fn.parse('?param=http%3A%2F%2Fsomeurl%3Fid%3D2837'), {param: 'http://someurl?id=2837'});
 });


### PR DESCRIPTION
Examples:
foo=bar&foo= -> ['bar', '']
foo=&foo=bar -> ['', 'bar']