### PR TITLE
Prevent non-array values from being wrapped in arrays

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,10 +65,12 @@ function parserForArrayFormat(opts) {
 		case 'bracket':
 			return function (key, value, accumulator) {
 				result = /(\[\])$/.exec(key);
-
 				key = key.replace(/\[\]$/, '');
 
-				if (!result || accumulator[key] === undefined) {
+				if (!result) {
+					accumulator[key] = value;
+					return;
+				} else if (accumulator[key] === undefined) {
 					accumulator[key] = [value];
 					return;
 				}

--- a/test/parse.js
+++ b/test/parse.js
@@ -97,6 +97,14 @@ test('query string having a single bracketed value and format option as `bracket
 	t.deepEqual(fn.parse('foo[]=bar', {arrayFormat: 'bracket'}), {foo: ['bar']});
 });
 
+test('query string not having a bracketed value and format option as `bracket`', t => {
+	t.deepEqual(fn.parse('foo=bar', {arrayFormat: 'bracket'}), {foo: 'bar'});
+});
+
+test('query string having a bracketed value and a single value and format option as `bracket`', t => {
+	t.deepEqual(fn.parse('foo=bar&baz[]=bar', {arrayFormat: 'bracket'}), {foo: 'bar', baz: ['bar']});
+});
+
 test('query strings having brackets arrays and format option as `bracket`', t => {
 	t.deepEqual(fn.parse('foo[]=bar&foo[]=baz', {
 		arrayFormat: 'bracket'


### PR DESCRIPTION
#89 (`4.3.3`) broke non-array values when `arrayFormat` was set to `bracket`.

`foo=bar` resulted in `{foo: ['bar']}` instead of `{foo: 'bar'}`