### PR TITLE
Allow ';' as query string delimiter as well as &.

### DIFF
--- a/index.js
+++ b/index.js
@@ -133,7 +133,7 @@ exports.parse = function (str, opts) {
 		return ret;
 	}
 
-	str.split('&').forEach(function (param) {
+	str.split(/&|;/).forEach(function (param) {
 		var parts = param.replace(/\+/g, ' ').split('=');
 		// Firefox (pre 40) decodes `%3D` to `=`
 		// https://github.com/sindresorhus/query-string/pull/37

--- a/test/parse.js
+++ b/test/parse.js
@@ -24,6 +24,13 @@ test('parse multiple query string', t => {
 	});
 });
 
+test('parse multiple query string with ; as delimiter', t => {
+	t.deepEqual(fn.parse('foo=bar;key=val'), {
+		foo: 'bar',
+		key: 'val'
+	});
+});
+
 test('parse query string without a value', t => {
 	t.deepEqual(fn.parse('foo'), {foo: null});
 	t.deepEqual(fn.parse('foo&key'), {


### PR DESCRIPTION
There is conflicting information on what is or is not accepted as a
query delimiter string, but at some point in history, both & and ; have
been used.

https://en.wikipedia.org/wiki/Uniform_Resource_Identifier#Generic_syntax

Since the ';' is only allowed as a delimiter in the url, it seems that we
should be be able to parse the query string by splitting on the ; in the
same way we split on the &.