### PR TITLE
Add better component decoder - fixes #98

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 'use strict';
 var strictUriEncode = require('strict-uri-encode');
 var objectAssign = require('object-assign');
+var decodeComponent = require('decode-uri-component');
 
 function encoderForArrayFormat(opts) {
 	switch (opts.arrayFormat) {
@@ -144,9 +145,9 @@ exports.parse = function (str, opts) {
 
 		// missing `=` should be `null`:
 		// http://w3.org/TR/2012/WD-url-20120524/#collect-url-parameters
-		val = val === undefined ? null : decodeURIComponent(val);
+		val = val === undefined ? null : decodeComponent(val);
 
-		formatter(decodeURIComponent(key), val, ret);
+		formatter(decodeComponent(key), val, ret);
 	});
 
 	return Object.keys(ret).sort().reduce(function (result, key) {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "decode"
   ],
   "dependencies": {
+    "decode-uri-component": "^0.2.0",
     "object-assign": "^4.1.0",
     "strict-uri-encode": "^1.0.0"
   },

--- a/readme.md
+++ b/readme.md
@@ -56,6 +56,8 @@ Parse a query string into an object. Leading `?` or `#` are ignored, so you can 
 
 The returned object is created with [`Object.create(null)`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/create) and thus does not have a `prototype`.
 
+URI components are decoded with [`decode-uri-component`](https://github.com/SamVerschueren/decode-uri-component).
+
 #### arrayFormat
 
 Type: `string`<br>

--- a/test/parse.js
+++ b/test/parse.js
@@ -169,3 +169,8 @@ test('circuit original -> parse - > stringify -> sorted original', t => {
 
 	t.deepEqual(fn.stringify(fn.parse(original, options), options), sortedOriginal);
 });
+
+test('decode keys and values', t => {
+	t.deepEqual(fn.parse('st%C3%A5le=foo'), {ståle: 'foo'});
+	t.deepEqual(fn.parse('foo=%7B%ab%%7C%de%%7D+%%7Bst%C3%A5le%7D%'), {foo: '{%ab%|%de%} %{ståle}%'});
+});


### PR DESCRIPTION
This is another approach in order to solve #98 and PR #97. It uses [`decode-uri-component`](https://github.com/SamVerschueren/decode-uri-component) which doesn't throw an error when it fails to decode. It tries to decode as much from the input as possible. Most of the time, it uses the native `decodeURIComponent`. Only when that one fails (edge cases for instance), a custom decoder is being used.

Should we document this somewhere?

---

Fixes #98 
Fixes #97 