### PR TITLE
Add `.parseUrl()` method

### DIFF
--- a/index.js
+++ b/index.js
@@ -204,3 +204,10 @@ exports.stringify = function (obj, opts) {
 		return x.length > 0;
 	}).join('&') : '';
 };
+
+exports.parseUrl = function (str, opts) {
+	return {
+		url: str.split('?')[0] || '',
+		queryParams: this.parse(this.extract(str), opts)
+	};
+};

--- a/readme.md
+++ b/readme.md
@@ -140,18 +140,16 @@ Extract a query string from a URL that can be passed into `.parse()`.
 
 ### .parseUrl(*string*, *[options]*)
 
-Extract the url and the query string as an object.
+Extract the URL and the query string as an object.
 
-Uses `.parse()`. For more information about *[options]* see the [parse function documentation](https://github.com/sindresorhus/query-string#parsestring-options).
+The `options` are the same as for `.parse()`.
 
-#### returns
+Returns an object with a `url` and `queryParams` property.
 
-Type: `object`<br>
-Default: `{ url: '', queryParams: {}}`
-
-- `url`: stands for URL.
-
-- `queryParams`: stands for the result of `parse()` on the query string.
+```js
+queryString.parseUrl('http://foo.bar?foo=bar')
+//=> {url: 'http://foo.bar', queryParams: {foo: 'bar'}}
+```
 
 
 ## Nesting

--- a/readme.md
+++ b/readme.md
@@ -138,6 +138,22 @@ queryString.stringify({foo: [1,2,3]});
 Extract a query string from a URL that can be passed into `.parse()`.
 
 
+### .parseUrl(*string*, *[options]*)
+
+Extract the url and the query string as an object.
+
+Uses `.parse()`. For more information about *[options]* see the [parse function documentation](https://github.com/sindresorhus/query-string#parsestring-options).
+
+#### returns
+
+Type: `object`<br>
+Default: `{ url: '', queryParams: {}}`
+
+- `url`: stands for URL.
+
+- `queryParams`: stands for the result of `parse()` on the query string.
+
+
 ## Nesting
 
 This module intentionally doesn't support nesting as it's not spec'd and varies between implementations, which causes a lot of [edge cases](https://github.com/visionmedia/node-querystring/issues).

--- a/test/parse-url.js
+++ b/test/parse-url.js
@@ -1,0 +1,17 @@
+import test from 'ava';
+import fn from '../';
+
+test('should handle strings with query string', t => {
+	t.deepEqual(fn.parseUrl('http://foo.bar?foo=bar'), {url: 'http://foo.bar', queryParams: {foo: 'bar'}});
+	t.deepEqual(fn.parseUrl('http://foo.bar?foo=bar&foo=baz'), {url: 'http://foo.bar', queryParams: {foo: ['bar', 'baz']}});
+});
+
+test('should handle strings not containing query string', t => {
+	t.deepEqual(fn.parseUrl('http://foo.bar/'), {url: 'http://foo.bar/', queryParams: {}});
+	t.deepEqual(fn.parseUrl(''), {url: '', queryParams: {}});
+});
+
+test('should throw for invalid values', t => {
+	t.throws(fn.parseUrl.bind(fn, null), TypeError);
+	t.throws(fn.parseUrl.bind(fn, undefined), TypeError);
+});


### PR DESCRIPTION
Fixes #103 

Added support for parsing full url, including tests and documentation.

**Usage**
`.parseUrl(string, [options])`

Returns `Object` 
```
{
    url: '',
    queryParams: {}
}
```
