### PR TITLE
Fix stringify for bracket mode with arrays containing null

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ function encoderForArrayFormat(options) {
 			};
 		case 'bracket':
 			return (key, value) => {
-				return value === null ? encode(key, options) : [
+				return value === null ? [encode(key, options), '[]'].join('') : [
 					encode(key, options),
 					'[]=',
 					encode(value, options)

--- a/package.json
+++ b/package.json
@@ -39,6 +39,8 @@
   },
   "devDependencies": {
     "ava": "*",
+    "deep-equal": "^1.0.1",
+    "fast-check": "^0.0.13",
     "xo": "*"
   }
 }

--- a/test/parse.js
+++ b/test/parse.js
@@ -107,6 +107,15 @@ test('query strings having brackets arrays and format option as `bracket`', t =>
 	}), {foo: ['bar', 'baz']});
 });
 
+test('query strings having brackets arrays with null and format option as `bracket`', t => {
+	t.deepEqual(m.parse('bar[]&foo[]=a&foo[]&foo[]=', {
+		arrayFormat: 'bracket'
+	}), {
+		foo: ['a', null, ''],
+		bar: [null]
+	});
+});
+
 test('query strings having indexed arrays and format option as `index`', t => {
 	t.deepEqual(m.parse('foo[0]=bar&foo[1]=baz', {
 		arrayFormat: 'index'

--- a/test/properties.js
+++ b/test/properties.js
@@ -1,0 +1,33 @@
+import deepEqual from 'deep-equal';
+import * as fc from 'fast-check';
+import test from 'ava';
+import m from '..';
+
+// Valid query parameters must follow:
+// - key can be any unicode string (not empty)
+// - value must be one of:
+// --> any unicode string
+// --> null
+// --> array containing values defined above (at least two items)
+const queryParamsArbitrary = fc.object({
+	key: fc.fullUnicodeString(1, 10),
+	values: [
+		fc.fullUnicodeString(),
+		fc.constant(null),
+		fc.array(fc.oneof(fc.fullUnicodeString(), fc.constant(null))).filter(a => a.length >= 2)
+	],
+	maxDepth: 0
+});
+
+const optionsArbitrary = fc.record({
+	arrayFormat: fc.constantFrom('bracket', 'index', 'none'),
+	strict: fc.boolean(),
+	encode: fc.boolean(),
+	sort: fc.boolean()
+});
+
+test('should read correctly from stringified query params', t => {
+	t.notThrows(() => fc.assert(
+		fc.property(queryParamsArbitrary, optionsArbitrary,
+		(obj, opts) => deepEqual(m.parse(m.stringify(obj, opts), opts), obj))));
+});

--- a/test/stringify.js
+++ b/test/stringify.js
@@ -108,6 +108,15 @@ test('array stringify representation with array brackets', t => {
 	}), 'bar[]=one&bar[]=two&foo');
 });
 
+test('array stringify representation with array brackets and null value', t => {
+	t.is(m.stringify({
+		foo: ['a', null, ''],
+		bar: [null]
+	}, {
+		arrayFormat: 'bracket'
+	}), 'bar[]&foo[]=a&foo[]&foo[]=');
+});
+
 test('array stringify representation with a bad array format', t => {
 	t.is(m.stringify({
 		foo: null,


### PR DESCRIPTION
I ran into an unexpected behaviour while running property based tests against query-string.

The unexpected behaviour is the following: when the settings `bracket` is enabled, null values contained inside arrays are badly exported causing problems on parsing side
```
m.stringify({bar: ['a', null, 'b']}, {arrayFormat: 'bracket'}) //=> "bar[]=a&bar&bar[]=b"
m.parse('bar[]=a&bar&bar[]=b', {arrayFormat: 'bracket'}) //=> {bar: [null, 'b']}
```

The commit contains both:
- the fix to serialize arrays correctly when enabling `bracket` mode
- the unit tests to assess the behaviour is correct
- the original property based test that detected the problem