### PR TITLE
Fixed issue with using encodeURIComponent instead if encodeURI in loose mode

### DIFF
--- a/index.js
+++ b/index.js
@@ -90,7 +90,7 @@ function parserForArrayFormat(options) {
 
 function encode(value, options) {
 	if (options.encode) {
-		return options.strict ? strictUriEncode(value) : encodeURIComponent(value);
+		return options.strict ? strictUriEncode(value) : encodeURI(value);
 	}
 
 	return value;
@@ -168,7 +168,6 @@ exports.stringify = (obj, options) => {
 		strict: true,
 		arrayFormat: 'none'
 	};
-
 	options = Object.assign(defaults, options);
 
 	if (options.sort === false) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "query-string",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "description": "Parse and stringify URL query strings",
   "license": "MIT",
   "repository": "sindresorhus/query-string",

--- a/test/stringify.js
+++ b/test/stringify.js
@@ -83,11 +83,13 @@ test('handle undefined and null values in array', t => {
 test('strict encoding', t => {
 	t.is(m.stringify({foo: '\'bar\''}), 'foo=%27bar%27');
 	t.is(m.stringify({foo: ['\'bar\'', '!baz']}), 'foo=%27bar%27&foo=%21baz');
+	t.is(m.stringify({date: '28/09/1979'}), 'date=28%2F09%2F1979');
 });
 
 test('loose encoding', t => {
 	t.is(m.stringify({foo: '\'bar\''}, {strict: false}), 'foo=\'bar\'');
 	t.is(m.stringify({foo: ['\'bar\'', '!baz']}, {strict: false}), 'foo=\'bar\'&foo=!baz');
+	t.is(m.stringify({date: '28/09/1979'}, {strict: false}), 'date=28/09/1979');
 });
 
 test('array stringify representation with array indexes', t => {


### PR DESCRIPTION
`stringify` functions must use 'encodeURI' encoding in loose mode ( `{strict: false}`) instead of encodeURIComponent which is for strict mode. This fix adds a possibility to use dates in query string without encoding slash (/). Some web servers need additional setup to support encoded dates like `date=28%2F09%2F1979` instead of `date=28/09/1979`

