### PR TITLE
New option 'postProcess' for parse()

### DIFF
--- a/index.js
+++ b/index.js
@@ -142,6 +142,9 @@ function parse(input, options) {
 		// Missing `=` should be `null`:
 		// http://w3.org/TR/2012/WD-url-20120524/#collect-url-parameters
 		value = value === undefined ? null : decodeComponent(value);
+		if (options.postProcess && typeof options.postProcess === 'function') {
+			value = options.postProcess(value);
+		}
 
 		formatter(decodeComponent(key), value, ret);
 	}
@@ -172,7 +175,8 @@ exports.stringify = (obj, options) => {
 	options = Object.assign(defaults, options);
 
 	if (options.sort === false) {
-		options.sort = () => {};
+		options.sort = () => {
+		};
 	}
 
 	const formatter = encoderForArrayFormat(options);

--- a/readme.md
+++ b/readme.md
@@ -92,6 +92,20 @@ queryString.parse('foo=1&foo=2&foo=3');
 //=> foo: [1,2,3]
 ```
 
+#### postProcess
+
+A function that post-processes the values. The caller must make sure that this function can handle all kinds of datatypes.
+
+```js
+queryString.parse('foo=bar', {postProcess: v => typeof v === 'string' ? v.toUpperCase() : v});
+//=> foo: 'BAR'
+```
+
+```js
+queryString.parse('foo[]=bar&foo[]=baz', {postProcess: v => typeof v === 'string' ? v.toUpperCase() : v});
+//=> foo: ['BAR', 'BAZ']
+```
+
 ### .stringify(*object*, *[options]*)
 
 Stringify an object into a query string, sorting the keys.

--- a/test/parse.js
+++ b/test/parse.js
@@ -143,6 +143,12 @@ test('query strings having ordered index arrays and format option as `index`', t
 	}), {bat: 'buz', foo: ['zero', 'two', 'one', 'three']});
 });
 
+test('query string having bracketed values and a single value and a postProcess function that uppercases', t => {
+	t.deepEqual(m.parse('foo=bar&baz[]=bar&baz[]=moo', {
+		postProcess: v => typeof v === 'string' ? v.toUpperCase() : v
+	}), {foo: 'BAR', 'baz[]': ['BAR', 'MOO']});
+});
+
 test('circuit parse -> stringify', t => {
 	const original = 'foo[3]=foo&foo[2]&foo[1]=one&foo[0]=&bat=buz';
 	const sortedOriginal = 'bat=buz&foo[0]=&foo[1]=one&foo[2]&foo[3]=foo';


### PR DESCRIPTION
Sometimes, I want to do some post-processing of all values, e.g. turn all characters into uppercase chars. I think it is useful to be able to do this during parsing. This way I can avoid copying the object or modifying it in-place.
The new option 'postProcess' allows the caller to pass a function that post-processes the values.

What do you think?