### PR TITLE
Fix failing tests in Node 10 caused by wrong sort option type

### DIFF
--- a/test/properties.js
+++ b/test/properties.js
@@ -23,8 +23,8 @@ const optionsArbitrary = fc.record({
 	arrayFormat: fc.constantFrom('bracket', 'index', 'none'),
 	strict: fc.boolean(),
 	encode: fc.boolean(),
-	sort: fc.boolean()
-});
+	sort: fc.constant(false)
+}, {withDeletedKeys: true});
 
 test('should read correctly from stringified query params', t => {
 	t.notThrows(() => fc.assert(


### PR DESCRIPTION
The `sort` parameter used in tests added #138 was using the wrong type: boolean instead of false or function.

It caused an issue when running tests against node 10 in travis.