### PR TITLE
Support stringifying objects into querystrings 

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,6 +27,14 @@ function encoderForArrayFormat(options) {
 					encode(value, options)
 				].join('');
 			};
+		case 'key':
+			return (parent, key, value) => {
+				return value === null ? [encode(parent, options), '[' + key + ']'].join('') : [
+					encode(parent, options),
+					'[' + key + ']=',
+					encode(value, options)
+				].join('');
+			};
 		default:
 			return (key, value) => {
 				return value === null ? encode(key, options) : [
@@ -208,6 +216,14 @@ exports.stringify = (obj, options) => {
 			}
 
 			return result.join('&');
+		}
+
+		if (typeof value === 'object') {
+			return Object.entries(value).reduce((acc, [k, v]) => {
+				acc.push(formatter(key, k, v));
+
+				return acc;
+			}, []).join('&');
 		}
 
 		return encode(key, options) + '=' + encode(value, options);

--- a/test/stringify.js
+++ b/test/stringify.js
@@ -117,6 +117,23 @@ test('array stringify representation with array brackets and null value', t => {
 	}), 'bar[]&foo[]=a&foo[]&foo[]=');
 });
 
+test('array stringify representation with array keys', t => {
+	t.is(m.stringify({
+		foo: null,
+		bar: {one: 'two', three: 'four'}
+	}, {
+		arrayFormat: 'key'
+	}), 'bar[one]=two&bar[three]=four&foo');
+});
+
+test('array stringify representation with array keys and null value', t => {
+	t.is(m.stringify({
+		foo: {a: null, b: 'c'}
+	}, {
+		arrayFormat: 'key'
+	}), 'foo[a]&foo[b]=c');
+});
+
 test('array stringify representation with a bad array format', t => {
 	t.is(m.stringify({
 		foo: null,


### PR DESCRIPTION
For whatever reason, I need to send these kinds of query strings to a server:

`_embed=1&settings[prefetch]=false&settings[expiry]=3600`

I figured I'd use a similar data structure; a JavaScript object, and was a bit annoyed when stringifying `{settings: { prefetch: false, expiry: 3600 }}` resulted in an url encoded [object object].

This fixes that. I added a new arrayFormat option, `key`. 

I tried giving a shot at `parse`, but we need one way conversion only at this point, and I couldn't figure it out in 10 minutes, so I gave up. Regular expressions are incomprehensible to me.