### PR TITLE
Add single parameter stringify option for array format

### DIFF
--- a/index.js
+++ b/index.js
@@ -197,6 +197,16 @@ exports.stringify = (obj, options) => {
 		}
 
 		if (Array.isArray(value)) {
+			if (options.arrayFormat === 'single') {
+				return [
+					encode(key, options),
+					'=[',
+					(value.length > 0 ? value.reduce((acc, current, index) =>
+						index ? [acc, ',', encode(current, options)].join('') : [acc, encode(current, options)].join(''), '') : ''),
+					']'
+				].join('');
+			}
+
 			const result = [];
 
 			for (const value2 of value.slice()) {

--- a/index.js
+++ b/index.js
@@ -76,6 +76,16 @@ function parserForArrayFormat(options) {
 
 				accumulator[key] = [].concat(accumulator[key], value);
 			};
+		case 'single':
+			return (key, value, accumulator) => {
+				if (accumulator[key] === undefined) {
+					if (value.indexOf(',') > -1) {
+						accumulator[key] = value.split(',').map((value) => decode(value, options));
+					} else {
+						accumulator[key] = decode(value, options);
+					}
+				}
+			};
 		default:
 			return (key, value, accumulator) => {
 				if (accumulator[key] === undefined) {
@@ -149,7 +159,7 @@ function parse(input, options) {
 
 		// Missing `=` should be `null`:
 		// http://w3.org/TR/2012/WD-url-20120524/#collect-url-parameters
-		value = value === undefined ? null : decode(value, options);
+		value = value === undefined ? null : options.arrayFormat === 'single' ? value : decode(value, options);
 
 		formatter(decode(key, options), value, ret);
 	}
@@ -200,10 +210,9 @@ exports.stringify = (obj, options) => {
 			if (options.arrayFormat === 'single') {
 				return [
 					encode(key, options),
-					'=[',
+					'=',
 					(value.length > 0 ? value.reduce((acc, current, index) =>
-						index ? [acc, ',', encode(current, options)].join('') : [acc, encode(current, options)].join(''), '') : ''),
-					']'
+						index ? [acc, ',', encode(current, options)].join('') : [acc, encode(current, options)].join(''), '') : '')
 				].join('');
 			}
 

--- a/readme.md
+++ b/readme.md
@@ -121,7 +121,7 @@ Default: `true`
 Type: `string`<br>
 Default: `'none'`
 
-Supports both `index` for an indexed array representation or `bracket` for a *bracketed* array representation.
+Supports indexed, bracket, and single parameter array representations.
 
 - `bracket`: stands for parsing correctly arrays with bracket representation on the query string, such as:
 
@@ -135,6 +135,13 @@ queryString.stringify({foo: [1,2,3]}, {arrayFormat: 'bracket'});
 ```js
 queryString.stringify({foo: [1,2,3]}, {arrayFormat: 'index'});
 // => foo[0]=1&foo[1]=2&foo[3]=3
+```
+
+- `single`: stands for representing an array with a single parameter declaration, such as:
+
+```js
+queryString.stringify({foo: [1,2,3]}, {arrayFormat: 'single'});
+// => foo=[1,2,3]
 ```
 
 - `none`: is the __default__ option and removes any bracket representation, such as:

--- a/test/parse.js
+++ b/test/parse.js
@@ -53,7 +53,7 @@ test('handle multiple of the same key', t => {
 	t.deepEqual(m.parse('foo=bar&foo=baz'), {foo: ['bar', 'baz']});
 });
 
-test('handle multiple values and preserve appearence order', t => {
+test('handle multiple values and preserve appearance order', t => {
 	t.deepEqual(m.parse('a=value&a='), {a: ['value', '']});
 	t.deepEqual(m.parse('a=&a=value'), {a: ['', 'value']});
 });
@@ -150,6 +150,32 @@ test('query strings having ordered index arrays and format option as `index`', t
 	t.deepEqual(m.parse('foo[102]=three&foo[2]=two&foo[100]=one&foo[0]=zero&bat=buz', {
 		arrayFormat: 'index'
 	}), {bat: 'buz', foo: ['zero', 'two', 'one', 'three']});
+});
+
+test('query strings having arrays defined with single param and format option as `single`', t => {
+	t.deepEqual(m.parse('foo=one,two,three,four%2Cfive&bar=something', {
+		arrayFormat: 'single'
+	}), {
+		bar: 'something',
+		foo: ['one', 'two', 'three', 'four,five']
+	});
+});
+
+test('query strings having arrays defined with single param and format option as `single` only read first instance of param', t => {
+	t.deepEqual(m.parse('foo=one,two,three&bar=something&foo=four,five,six&bar=else', {
+		arrayFormat: 'single'
+	}), {
+		bar: 'something',
+		foo: ['one', 'two', 'three']
+	});
+});
+
+test('query strings having arrays defined with single param and format option as `single` only read first instance of param', t => {
+	t.deepEqual(m.parse('foo=a%2Cb,c', {
+		arrayFormat: 'single'
+	}), {
+		foo: ['a,b', 'c']
+	});
 });
 
 test('circuit parse -> stringify', t => {

--- a/test/stringify.js
+++ b/test/stringify.js
@@ -116,7 +116,7 @@ test('array stringify representation with single parameter array', t => {
 		zaz: ['oh my, ', 'wow']
 	}, {
 		arrayFormat: 'single'
-	}), 'abc=[red,blue%2Cgreen]&bar=[one,two]&foo&zaz=[oh%20my%2C%20,wow]');
+	}), 'abc=red,blue%2Cgreen&bar=one,two&foo&zaz=oh%20my%2C%20,wow');
 });
 
 test('array stringify representation with array brackets and null value', t => {

--- a/test/stringify.js
+++ b/test/stringify.js
@@ -108,6 +108,17 @@ test('array stringify representation with array brackets', t => {
 	}), 'bar[]=one&bar[]=two&foo');
 });
 
+test('array stringify representation with single parameter array', t => {
+	t.is(m.stringify({
+		foo: null,
+		bar: ['one', 'two'],
+		abc: ['red', 'blue,green'],
+		zaz: ['oh my, ', 'wow']
+	}, {
+		arrayFormat: 'single'
+	}), 'abc=[red,blue%2Cgreen]&bar=[one,two]&foo&zaz=[oh%20my%2C%20,wow]');
+});
+
 test('array stringify representation with array brackets and null value', t => {
 	t.is(m.stringify({
 		foo: ['a', null, ''],


### PR DESCRIPTION
This adds a new option for `arrayFormat` that allows an array to be stringified as a single query parameter. An example of using this format is if an application/WAF does not allow multiple declarations of a query parameter to limit possibilities of a payload becoming malicious once concatenated by the receiving API.

These are a few links further describing HTTP parameter pollution:
https://www.owasp.org/index.php/Testing_for_HTTP_Parameter_pollution_(OTG-INPVAL-004)
https://tacticalwebappsec.blogspot.com/2009/05/http-parameter-pollution.html
https://capec.mitre.org/data/definitions/460.html
https://medium.com/@aneeskhan/how-i-bypassed-open-redirection-tokens-using-http-parameter-pollution-ea5be084a0f4