### PR TITLE
Bump fast-check version and adapt properties

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
 	"devDependencies": {
 		"ava": "*",
 		"deep-equal": "^1.0.1",
-		"fast-check": "^1.0.1",
+		"fast-check": "^1.5.0",
 		"xo": "*"
 	}
 }

--- a/test/properties.js
+++ b/test/properties.js
@@ -9,20 +9,19 @@ import m from '..';
 // --> any unicode string
 // --> null
 // --> array containing values defined above (at least two items)
-const queryParamsArbitrary = fc.object({
-	key: fc.fullUnicodeString(1, 10),
-	values: [
+const queryParamsArbitrary = fc.dictionary(
+	fc.fullUnicodeString(1, 10),
+	fc.oneof(
 		fc.fullUnicodeString(),
 		fc.constant(null),
-		fc.array(fc.oneof(fc.fullUnicodeString(), fc.constant(null))).filter(a => a.length >= 2)
-	],
-	maxDepth: 0
-});
+		fc.array(fc.oneof(fc.fullUnicodeString(), fc.constant(null)), 2, 10)
+	)
+);
 
 const optionsArbitrary = fc.record({
 	arrayFormat: fc.constantFrom('bracket', 'index', 'none'),
 	strict: fc.boolean(),
-	encode: fc.boolean(),
+	encode: fc.constant(true),
 	sort: fc.constant(false)
 }, {withDeletedKeys: true});
 


### PR DESCRIPTION
Content of this review:
- bump of fast-check version
- move from `fc.object` - able to construct deep objects - to `fc.dictionary` - more adapted for this case
- use of `fc.array(arbitrary, minSize, maxSize)` for better array generation performances
- fix the property code that allowed `encode: false` case - *PR https://github.com/dubzzz/fast-check/pull/175 (not merged  yet) enhances the corner case detection on strings and report an error for this case*