### PR TITLE
set default arrayFormat

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 'use strict';
 const strictUriEncode = require('strict-uri-encode');
 const decodeComponent = require('decode-uri-component');
+
 let DEFAULT_ARRAY_FORMAT = 'none';
 
 function encoderForArrayFormat(options) {
@@ -231,6 +232,6 @@ exports.parseUrl = (input, options) => {
 	};
 };
 
-exports.setGlobalArrayFormat = (format) => {
+exports.setGlobalArrayFormat = format => {
 	DEFAULT_ARRAY_FORMAT = format;
 };

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 'use strict';
 const strictUriEncode = require('strict-uri-encode');
 const decodeComponent = require('decode-uri-component');
+let DEFAULT_ARRAY_FORMAT = 'none';
 
 function encoderForArrayFormat(options) {
 	switch (options.arrayFormat) {
@@ -128,7 +129,7 @@ function extract(input) {
 }
 
 function parse(input, options) {
-	options = Object.assign({decode: true, arrayFormat: 'none'}, options);
+	options = Object.assign({decode: true, arrayFormat: DEFAULT_ARRAY_FORMAT}, options);
 
 	const formatter = parserForArrayFormat(options);
 
@@ -179,7 +180,7 @@ exports.stringify = (obj, options) => {
 	options = Object.assign({
 		encode: true,
 		strict: true,
-		arrayFormat: 'none'
+		arrayFormat: DEFAULT_ARRAY_FORMAT
 	}, options);
 
 	const formatter = encoderForArrayFormat(options);
@@ -228,4 +229,8 @@ exports.parseUrl = (input, options) => {
 		url: input.split('?')[0] || '',
 		query: parse(extract(input), options)
 	};
+};
+
+exports.setGlobalArrayFormat = (format) => {
+	DEFAULT_ARRAY_FORMAT = format;
 };

--- a/readme.md
+++ b/readme.md
@@ -97,6 +97,10 @@ queryString.parse('foo=1&foo=2&foo=3');
 //=> foo: [1,2,3]
 ```
 
+### .setGlobalArrayFormat(*arrayFormat*)
+
+As above, set an arrayFormat as global default setting, convenient for all same setting in one project.
+
 ### .stringify(*object*, *[options]*)
 
 Stringify an object into a query string, sorting the keys.


### PR DESCRIPTION
Add the ability to set an arrayFormat as global default setting
convenient for all same setting in one project.

like `jQuery.ajaxSetup()`