### PR TITLE
Support various targets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 yarn.lock
+dist/

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "query-string",
-	"version": "6.2.0",
+	"version": "7.0.0",
 	"description": "Parse and stringify URL query strings",
 	"license": "MIT",
 	"repository": "sindresorhus/query-string",
@@ -12,10 +12,21 @@
 	"engines": {
 		"node": ">=6"
 	},
+	"main": "dist/query-string.js",
+	"umd:main": "dist/query-string.umd.js",
+	"module": "dist/query-string.mjs",
+	"source": "index.js",
 	"scripts": {
+		"build": "microbundle",
 		"test": "xo && ava"
 	},
 	"files": [
+		"dist/query-string.js",
+		"dist/query-string.js.map",
+		"dist/query-string.mjs",
+		"dist/query-string.mjs.map",
+		"dist/query-string.umd.js",
+		"dist/query-string.umd.js.map",
 		"index.js"
 	],
 	"keywords": [
@@ -41,6 +52,7 @@
 		"ava": "^0.25.0",
 		"deep-equal": "^1.0.1",
 		"fast-check": "^1.5.0",
+		"microbundle": "^0.6.0",
 		"xo": "^0.23.0"
 	}
 }


### PR DESCRIPTION
I wasn't paying attention and installed the latest 6.x version instead of 5.x, which didn't properly transpile through webpack. I'm not the only one: https://stackoverflow.com/questions/49954618/babel-not-transpiling-arrow-functions-webpack

I think this would be a useful addition.