### PR TITLE
Add `sort` option to the `.parse()` method

### DIFF
--- a/index.js
+++ b/index.js
@@ -128,7 +128,7 @@ function extract(input) {
 }
 
 function parse(input, options) {
-	options = Object.assign({decode: true, arrayFormat: 'none'}, options);
+	options = Object.assign({decode: true, arrayFormat: 'none', sort: true}, options);
 
 	const formatter = parserForArrayFormat(options);
 
@@ -153,6 +153,10 @@ function parse(input, options) {
 		value = value === undefined ? null : decode(value, options);
 
 		formatter(decode(key, options), value, ret);
+	}
+
+	if (!options.sort) {
+		return ret;
 	}
 
 	return Object.keys(ret).sort().reduce((result, key) => {

--- a/test/parse.js
+++ b/test/parse.js
@@ -183,3 +183,10 @@ test('decode keys and values', t => {
 test('disable decoding of keys and values', t => {
 	t.deepEqual(m.parse('tags=postal%20office,burger%2C%20fries%20and%20coke', {decode: false}), {tags: 'postal%20office,burger%2C%20fries%20and%20coke'});
 });
+
+test('parse query string, but don\'t sort the keys alphabetically', t => {
+	const parsedUnsorted = m.parse('?a=1&c=2&b=3', {sort: false});
+	const parsedSorted = m.parse('?a=1&c=2&b=3');
+	t.deepEqual(Object.keys(parsedUnsorted), ['a', 'c', 'b']);
+	t.deepEqual(Object.keys(parsedSorted), ['a', 'b', 'c']);
+});

--- a/test/parse.js
+++ b/test/parse.js
@@ -184,7 +184,7 @@ test('disable decoding of keys and values', t => {
 	t.deepEqual(m.parse('tags=postal%20office,burger%2C%20fries%20and%20coke', {decode: false}), {tags: 'postal%20office,burger%2C%20fries%20and%20coke'});
 });
 
-test('parse query string, but don\'t sort the keys alphabetically', t => {
+test('`sort` option', t => {
 	const parsedUnsorted = m.parse('?a=1&c=2&b=3', {sort: false});
 	const parsedSorted = m.parse('?a=1&c=2&b=3');
 	t.deepEqual(Object.keys(parsedUnsorted), ['a', 'c', 'b']);


### PR DESCRIPTION
*Reason for change:* 

I have a use case for a Search Input component I'm making that needs to interact with the URL as a source of truth for any filtering that needs to be done in my UI. The user would typically go through the following scenario:

1. Search input currently has the following chips: `Cluster:` `DockerSwarm` `Namespace:` `test` and the corresponding search query is `?Cluster=DockerSwarm&Namespace=test`
2. If they add another search term for "Deployment=nginx" then the chips show up as `Cluster:` `DockerSwarm` `Deployment:` `nginx` `Namespace:` `test`.  The corresponding search query would be `?Cluster=DockerSwarm&Namespace=test&Deployment=nginx`. The `query-string` library will sort the keys alphabetically when it parses the query string, and that causes inconsistencies between the order you see in the search query and the order of the chips in the search input.

To prevent things from jumping around due to the sorting, I thought i'd add an option to prevent sorting when we pass `{sort: false}`. By default it'll be true.

Let me know if this makes sense. Thought i'd send a PR 🤷‍♂️ 