### PR TITLE
Fix sort example for `stringify` method

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -153,7 +153,7 @@ Supports both `Function` as a custom sorting function or `false` to disable sort
 ```js
 const order = ['c', 'a', 'b'];
 queryString.stringify({ a: 1, b: 2, c: 3}, {
-	sort: (m, n) => order.indexOf(m) >= order.indexOf(n)
+	sort: (m, n) => order.indexOf(m) - order.indexOf(n)
 });
 // => 'c=3&a=1&b=2'
 ```


### PR DESCRIPTION
Since the sort option of stringify eventually gets passed to Array.sort it needs to return a Number, not a Boolean. So by subtracting the indexes of the keys rather than comparing them, the keys will be sorted properly.