### PR TITLE
fix: change `const` to `let`

### DIFF
--- a/index.js
+++ b/index.js
@@ -133,7 +133,7 @@ function parse(input, options) {
 	const formatter = parserForArrayFormat(options);
 
 	// Create an object with no prototype
-	const ret = Object.create(null);
+	let ret = Object.create(null);
 
 	if (typeof input !== 'string') {
 		return ret;


### PR DESCRIPTION
**Change reason:**

I'm not sure this is right, if I'm wrong, please let me know. Thanks!

I think `parserForArrayFormat()` is a higher order function, it returns a new function, which makes a closure. 

and In this returned function, the parameter `accumulator` was modified directly. 
``` javascript
(key, value, accumulator) => {
  if (accumulator[key] === undefined) {
    accumulator[key] = value;
    return;
  }

  accumulator[key] = [].concat(accumulator[key], value);
};
```

So I think when we call `formatter(decode(key, options), value, ret)`(the returned function), actually our parameter `ret` has been modified directly. So I think in this situation we should use `let` not `const`.

If I am understanding correctly, there are a few similarly situation in the code, maybe I can help to change it.