### PR TITLE
Add `comma` format to the `arrayFormat` option

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -29,7 +29,7 @@ export interface ParseOptions {
 	 *    queryString.parse('foo=1&foo=2&foo=3');
 	 *    //=> foo: [1,2,3]
 	 */
-	readonly arrayFormat?: 'bracket' | 'index' | 'none';
+	readonly arrayFormat?: 'bracket' | 'index' | 'comma' | 'none';
 }
 
 export interface ParsedQuery {
@@ -100,7 +100,7 @@ export interface StringifyOptions {
 	 *    queryString.stringify({foo: [1,2,3]});
 	 *    // => foo=1&foo=2&foo=3
 	 */
-	readonly arrayFormat?: 'bracket' | 'index' | 'none';
+	readonly arrayFormat?: 'bracket' | 'index' | 'comma' | 'none';
 
 	/**
 	 * Supports both `Function` as a custom sorting function or `false` to disable sorting.

--- a/index.js
+++ b/index.js
@@ -89,6 +89,12 @@ function parserForArrayFormat(options) {
 
 				accumulator[key] = [].concat(accumulator[key], value);
 			};
+		case 'comma':
+			return (key, value, accumulator) => {
+				const isArray = typeof value === 'string' && value.split('').indexOf(',') > -1;
+				const newValue = isArray ? value.split(',') : value;
+				accumulator[key] = newValue;
+			};
 		default:
 			return (key, value, accumulator) => {
 				if (accumulator[key] === undefined) {

--- a/index.js
+++ b/index.js
@@ -28,6 +28,16 @@ function encoderForArrayFormat(options) {
 				}
 				return [...result, [encode(key, options), '[]=', encode(value, options)].join('')];
 			};
+		case 'comma':
+			return key => (result, value, index) => {
+				if (!value) {
+					return result;
+				}
+				if (index === 0) {
+					return [[encode(key, options), '=', encode(value, options)].join('')];
+				}
+				return [[result, encode(value, options)].join(',')];
+			};
 		default:
 			return key => (result, value) => {
 				if (value === undefined) {

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -20,6 +20,7 @@ expectType<string>(
 );
 expectType<string>(queryString.stringify({foo: 'bar'}, {arrayFormat: 'index'}));
 expectType<string>(queryString.stringify({foo: 'bar'}, {arrayFormat: 'none'}));
+expectType<string>(queryString.stringify({foo: 'bar'}, {arrayFormat: 'comma'}));
 expectType<string>(queryString.stringify({foo: 'bar'}, {sort: false}));
 const order = ['c', 'a', 'b'];
 expectType<string>(
@@ -47,6 +48,9 @@ expectType<queryString.ParsedQuery>(
 expectType<queryString.ParsedQuery>(
 	queryString.parse('?foo=bar', {arrayFormat: 'none'})
 );
+expectType<queryString.ParsedQuery>(
+	queryString.parse('?foo=bar', {arrayFormat: 'comma'})
+);
 
 // Parse URL
 expectType<queryString.ParsedUrl>(queryString.parseUrl('?foo=bar'));
@@ -62,6 +66,9 @@ expectType<queryString.ParsedUrl>(
 );
 expectType<queryString.ParsedUrl>(
 	queryString.parseUrl('?foo=bar', {arrayFormat: 'none'})
+);
+expectType<queryString.ParsedUrl>(
+	queryString.parseUrl('?foo=bar', {arrayFormat: 'comma'})
 );
 
 // Extract

--- a/readme.md
+++ b/readme.md
@@ -90,6 +90,13 @@ queryString.parse('foo[0]=1&foo[1]=2&foo[3]=3', {arrayFormat: 'index'});
 //=> foo: [1,2,3]
 ```
 
+- `comma`: stands for parsing separating array elements with comma, such as:
+
+```js
+queryString.parse('foo=1,2,3', {arrayFormat: 'comma'});
+//=> foo: [1,2,3]
+```
+
 - `none`: is the **default** option and removes any bracket representation, such as:
 
 ```js
@@ -136,6 +143,14 @@ queryString.stringify({foo: [1,2,3]}, {arrayFormat: 'bracket'});
 queryString.stringify({foo: [1,2,3]}, {arrayFormat: 'index'});
 // => foo[0]=1&foo[1]=2&foo[3]=3
 ```
+
+- `comma`: stands for parsing separating array elements with comma, such as:
+
+```js
+queryString.stringify({foo: [1,2,3]}, {arrayFormat: 'comma'});
+// => foo=1,2,3
+```
+
 
 - `none`: is the __default__ option and removes any bracket representation, such as:
 

--- a/test/parse.js
+++ b/test/parse.js
@@ -107,12 +107,27 @@ test('query strings having brackets arrays and format option as `bracket`', t =>
 	}), {foo: ['bar', 'baz']});
 });
 
+test('query strings having comma separated arrays and format option as `comma`', t => {
+	t.deepEqual(m.parse('foo=bar,baz', {
+		arrayFormat: 'comma'
+	}), {foo: ['bar', 'baz']});
+});
+
 test('query strings having brackets arrays with null and format option as `bracket`', t => {
 	t.deepEqual(m.parse('bar[]&foo[]=a&foo[]&foo[]=', {
 		arrayFormat: 'bracket'
 	}), {
 		foo: ['a', null, ''],
 		bar: [null]
+	});
+});
+
+test('query strings having comma separated arrays with null and format option as `comma`', t => {
+	t.deepEqual(m.parse('bar&foo=a,', {
+		arrayFormat: 'comma'
+	}), {
+		foo: ['a', ''],
+		bar: null
 	});
 });
 

--- a/test/stringify.js
+++ b/test/stringify.js
@@ -117,6 +117,24 @@ test('array stringify representation with array brackets and null value', t => {
 	}), 'bar[]&foo[]=a&foo[]&foo[]=');
 });
 
+test('array stringify representation with array commas', t => {
+	t.is(m.stringify({
+		foo: null,
+		bar: ['one', 'two']
+	}, {
+		arrayFormat: 'comma'
+	}), 'bar=one,two&foo');
+});
+
+test('array stringify representation with array commas and null value', t => {
+	t.is(m.stringify({
+		foo: ['a', null, ''],
+		bar: [null]
+	}, {
+		arrayFormat: 'comma'
+	}), 'foo=a');
+});
+
 test('array stringify representation with a bad array format', t => {
 	t.is(m.stringify({
 		foo: null,


### PR DESCRIPTION
This pull requests adds fourth `arrayFormat` option, named `comma`. We needed this for our project, as we needed to support arrays in query in below shape...

`foo=1,2,3,4,5,6,7,8`

This format is mainly used to shorten URLs which include things as identifiers, where there is expected to be a lot of them.

 On the way to add this feature I had to slightly reimplement `encoderForArrayFormat` to use `Array.prototype.reduce` instead of previous `for .. in`