### PR TITLE
Fix failing test and `ParsedQuery` TypeScript type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -33,7 +33,7 @@ export interface ParseOptions {
 }
 
 export interface ParsedQuery {
-	readonly [key: string]: string | string[] | undefined;
+	readonly [key: string]: string | string[] | null | undefined;
 }
 
 /**

--- a/test/stringify.js
+++ b/test/stringify.js
@@ -134,7 +134,7 @@ test('array stringify representation with array indexes and sparse array', t => 
 
 test('should sort keys in given order', t => {
 	const order = ['c', 'a', 'b'];
-	const sort = (key1, key2) => order.indexOf(key1) >= order.indexOf(key2);
+	const sort = (key1, key2) => order.indexOf(key1) - order.indexOf(key2);
 
 	t.is(m.stringify({a: 'foo', b: 'bar', c: 'baz'}, {sort}), 'c=baz&a=foo&b=bar');
 });


### PR DESCRIPTION
- Fixes the failing test `should sort keys in given order` of the stringify function. The test's sort function didn't result in the specified order (expected: `c=baz&a=foo&b=bar`, actual: `a=foo&b=bar&c=baz`).
- Fixes the `ParsedQuery` type. Values may be `null` as seen [here](https://github.com/sindresorhus/query-string/blob/c138b1123462882bb2b44d8ecac83f0b372b53eb/index.js#L157).

