### PR TITLE
Fix `split-on-first` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
 		"searchparams"
 	],
 	"dependencies": {
+		"split-on-first": "^1.0.0",
 		"decode-uri-component": "^0.2.0",
 		"strict-uri-encode": "^2.0.0"
 	},
@@ -42,7 +43,6 @@
 		"ava": "^1.3.1",
 		"deep-equal": "^1.0.1",
 		"fast-check": "^1.5.0",
-		"split-on-first": "^1.0.0",
 		"tsd-check": "^0.3.0",
 		"xo": "^0.24.0"
 	}


### PR DESCRIPTION
Build is failing as split-on-first is devDependancy and not a "regular" dependancy