### PR TITLE
Support stringifying array containing value 0

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,7 +37,7 @@ function encoderForArrayFormat(options) {
 
 		case 'comma':
 			return key => (result, value, index) => {
-				if (!value) {
+				if (value === null || value === undefined || value.length === 0) {
 					return result;
 				}
 

--- a/test/stringify.js
+++ b/test/stringify.js
@@ -135,6 +135,15 @@ test('array stringify representation with array commas and null value', t => {
 	}), 'foo=a');
 });
 
+test('array stringify representation with array commas and 0 value', t => {
+	t.is(queryString.stringify({
+		foo: ['a', null, 0],
+		bar: [null]
+	}, {
+		arrayFormat: 'comma'
+	}), 'foo=a,0');
+});
+
 test('array stringify representation with a bad array format', t => {
 	t.is(queryString.stringify({
 		foo: null,


### PR DESCRIPTION
For whatever reason, I need to send these kind of query strings to a server:
```
idList=0,1,2,3
```
Before : 0 value was ignored.  
After : 0 value is well added to the final string