### PR TITLE
Add `sort` option to `.parse()`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -36,11 +36,11 @@ export interface ParseOptions {
 	readonly arrayFormat?: 'bracket' | 'index' | 'comma' | 'none';
 
 	/**
-	 * @default `false`
-	 * 
 	 * Supports both `Function` as a custom sorting function or `false` to disable sorting.
 	 *
 	 * If omitted, keys are sorted using `Array#sort`, which means, converting them to strings and comparing strings in Unicode code point order.
+	 *
+	 * @default true
 	 *
 	 * @example
 	 *
@@ -48,10 +48,10 @@ export interface ParseOptions {
 	 * queryString.parse('?a=one&b=two&c=three', {
 	 * 	sort: (itemLeft, itemRight) => order.indexOf(itemLeft) - order.indexOf(itemRight)
 	 * });
-	 * // => {'c': 'three', 'a': 'one', 'b': 'two'}
+	 * // => {c: 'three', a: 'one', b: 'two'}
 	 *
 	 * queryString.parse('?a=one&c=three&b=two', {sort: false});
-	 * // => {'a': 'one', 'c': 'three', 'b': 'two'}
+	 * // => {a: 'one', c: 'three', b: 'two'}
 	 */
 	readonly sort?: ((itemLeft: string, itemRight: string) => number) | false;
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -36,11 +36,24 @@ export interface ParseOptions {
 	readonly arrayFormat?: 'bracket' | 'index' | 'comma' | 'none';
 
 	/**
-	 * Sort the parsed keys.
+	 * @default `false`
+	 * 
+	 * Supports both `Function` as a custom sorting function or `false` to disable sorting.
 	 *
-	 * @default true
+	 * If omitted, keys are sorted using `Array#sort`, which means, converting them to strings and comparing strings in Unicode code point order.
+	 *
+	 * @example
+	 *
+	 * const order = ['c', 'a', 'b'];
+	 * queryString.parse('?a=one&b=two&c=three', {
+	 * 	sort: (itemLeft, itemRight) => order.indexOf(itemLeft) - order.indexOf(itemRight)
+	 * });
+	 * // => {'c': 'three', 'a': 'one', 'b': 'two'}
+	 *
+	 * queryString.parse('?a=one&c=three&b=two', {sort: false});
+	 * // => {'a': 'one', 'c': 'three', 'b': 'two'}
 	 */
-	readonly sort?: boolean;
+	readonly sort?: ((itemLeft: string, itemRight: string) => number) | false;
 
 }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -34,6 +34,14 @@ export interface ParseOptions {
 	 *    //=> foo: [1, 2, 3]
 	 */
 	readonly arrayFormat?: 'bracket' | 'index' | 'comma' | 'none';
+
+	/**
+	 * Sort the parsed keys.
+	 *
+	 * @default true
+	 */
+	readonly sort?: boolean;
+
 }
 
 export interface ParsedQuery {

--- a/index.js
+++ b/index.js
@@ -203,7 +203,11 @@ function parse(input, options) {
 		formatter(decode(key, options), value, ret);
 	}
 
-	return (options.sort === true ? Object.keys(ret).sort() : Object.keys(ret)).reduce((result, key) => {
+	if (options.sort === false) {
+		return ret;
+	}
+
+	return (options.sort === true ? Object.keys(ret).sort() : Object.keys(ret).sort(options.sort)).reduce((result, key) => {
 		const value = ret[key];
 		if (Boolean(value) && typeof value === 'object' && !Array.isArray(value)) {
 			// Sort object keys, not values

--- a/index.js
+++ b/index.js
@@ -174,6 +174,7 @@ function extract(input) {
 function parse(input, options) {
 	options = Object.assign({
 		decode: true,
+		sort: true,
 		arrayFormat: 'none'
 	}, options);
 
@@ -202,7 +203,7 @@ function parse(input, options) {
 		formatter(decode(key, options), value, ret);
 	}
 
-	return Object.keys(ret).sort().reduce((result, key) => {
+	return (options.sort === true ? Object.keys(ret).sort() : Object.keys(ret)).reduce((result, key) => {
 		const value = ret[key];
 		if (Boolean(value) && typeof value === 'object' && !Array.isArray(value)) {
 			// Sort object keys, not values

--- a/readme.md
+++ b/readme.md
@@ -96,6 +96,13 @@ queryString.parse('foo=1&foo=2&foo=3');
 //=> foo: [1, 2, 3]
 ```
 
+##### sort
+
+Type: `boolean`<br>
+Default: `true`
+
+Parse the keys and values into an object sorted by key when `true`, or in the order they appear in the query string when `false`.
+
 ### .stringify(object, [options])
 
 Stringify an object into a query string and sorting the keys.

--- a/readme.md
+++ b/readme.md
@@ -98,10 +98,10 @@ queryString.parse('foo=1&foo=2&foo=3');
 
 ##### sort
 
-Type: `boolean`<br>
+Type: `Function | boolean`<br>
 Default: `true`
 
-Parse the keys and values into an object sorted by key when `true`, or in the order they appear in the query string when `false`.
+Supports both `Function` as a custom sorting function or `false` to disable sorting.
 
 ### .stringify(object, [options])
 

--- a/test/parse.js
+++ b/test/parse.js
@@ -25,18 +25,28 @@ test('parse multiple query string', t => {
 });
 
 test('parse multiple query string retain order when not sorted', t => {
-	const expectedKeys = ['one', 'two', 'three'];
-	const parsed = queryString.parse('one=foo&two=bar&three=yay', {sort: false});
+	const expectedKeys = ['b', 'a', 'c'];
+	const parsed = queryString.parse('b=foo&a=bar&c=yay', {sort: false});
 	Object.keys(parsed).forEach((key, index) => {
 		t.is(key, expectedKeys[index]);
 	});
 });
 
 test('parse multiple query string sorted keys', t => {
-	const expectedKeys = ['one', 'three', 'two'];
-	const parsed = queryString.parse('one=foo&two=bar&three=yay');
+	const fixture = ['a', 'b', 'c'];
+	const parsed = queryString.parse('a=foo&c=bar&b=yay');
 	Object.keys(parsed).forEach((key, index) => {
-		t.is(key, expectedKeys[index]);
+		t.is(key, fixture[index]);
+	});
+});
+
+test('should sort parsed keys in given order', t => {
+	const fixture = ['c', 'a', 'b'];
+	const sort = (key1, key2) => fixture.indexOf(key1) - fixture.indexOf(key2);
+
+	const parsed = queryString.parse('a=foo&b=bar&c=yay', {sort});
+	Object.keys(parsed).forEach((key, index) => {
+		t.is(key, fixture[index]);
 	});
 });
 

--- a/test/parse.js
+++ b/test/parse.js
@@ -24,6 +24,22 @@ test('parse multiple query string', t => {
 	});
 });
 
+test('parse multiple query string retain order when not sorted', t => {
+	const expectedKeys = ['one', 'two', 'three'];
+	const parsed = queryString.parse('one=foo&two=bar&three=yay', {sort: false});
+	Object.keys(parsed).forEach((key, index) => {
+		t.is(key, expectedKeys[index]);
+	});
+});
+
+test('parse multiple query string sorted keys', t => {
+	const expectedKeys = ['one', 'three', 'two'];
+	const parsed = queryString.parse('one=foo&two=bar&three=yay');
+	Object.keys(parsed).forEach((key, index) => {
+		t.is(key, expectedKeys[index]);
+	});
+});
+
 test('parse query string without a value', t => {
 	t.deepEqual(queryString.parse('foo'), {foo: null});
 	t.deepEqual(queryString.parse('foo&key'), {


### PR DESCRIPTION
In this version we introduce a parse function option called `sort` that defaults to `true` (current default behaviour). When `sort` is `false`, query string keys are not sorted when parsed, and appear in the resulting object in the order they appear in the query string.

Fixes #176 
Closes #162