### PR TITLE
Fix the TypeScript types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -90,7 +90,7 @@ export interface ParseOptions {
 }
 
 export interface ParsedQuery<T = string> {
-	[key: string]: T | Array<T> | null | undefined;
+	[key: string]: T | T[] | null | undefined;
 }
 
 /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -112,9 +112,9 @@ The returned object is created with [`Object.create(null)`](https://developer.mo
 
 @param query - The query string to parse.
 */
-export function parse(query: string, options: { parseBooleans: true, parseNumbers: true } & ParseOptions): ParsedQueryWithBooleansAndNumbers;
-export function parse(query: string, options: { parseBooleans: true } & ParseOptions): ParsedQueryWithBooleans;
-export function parse(query: string, options: { parseNumbers: true } & ParseOptions): ParsedQueryWithNumbers;
+export function parse(query: string, options: {parseBooleans: true, parseNumbers: true} & ParseOptions): ParsedQueryWithBooleansAndNumbers;
+export function parse(query: string, options: {parseBooleans: true} & ParseOptions): ParsedQueryWithBooleans;
+export function parse(query: string, options: {parseNumbers: true} & ParseOptions): ParsedQueryWithNumbers;
 export function parse(query: string, options?: ParseOptions): ParsedQuery;
 
 export interface ParsedUrl {

--- a/index.d.ts
+++ b/index.d.ts
@@ -90,7 +90,19 @@ export interface ParseOptions {
 }
 
 export interface ParsedQuery {
-	readonly [key: string]: string | number | boolean | Array<string | number | boolean> | null | undefined;
+	[key: string]: string | Array<string> | null | undefined;
+}
+
+export interface ParsedQueryWithBooleans {
+	[key: string]: string | boolean | Array<string | boolean> | null | undefined;
+}
+
+export interface ParsedQueryWithNumbers {
+	[key: string]: string | number | Array<string | number> | null | undefined;
+}
+
+export interface ParsedQueryWithBooleansAndNumbers {
+	[key: string]: string | number | boolean | Array<string | number | boolean> | null | undefined;
 }
 
 /**
@@ -100,6 +112,9 @@ The returned object is created with [`Object.create(null)`](https://developer.mo
 
 @param query - The query string to parse.
 */
+export function parse(query: string, options: { parseBooleans: true, parseNumbers: true } & ParseOptions): ParsedQueryWithBooleansAndNumbers;
+export function parse(query: string, options: { parseBooleans: true } & ParseOptions): ParsedQueryWithBooleans;
+export function parse(query: string, options: { parseNumbers: true } & ParseOptions): ParsedQueryWithNumbers;
 export function parse(query: string, options?: ParseOptions): ParsedQuery;
 
 export interface ParsedUrl {

--- a/index.d.ts
+++ b/index.d.ts
@@ -90,7 +90,7 @@ export interface ParseOptions {
 }
 
 export interface ParsedQuery {
-	[key: string]: string | Array<string> | null | undefined;
+	[key: string]: string | string[] | null | undefined;
 }
 
 export interface ParsedQueryWithBooleans {

--- a/index.d.ts
+++ b/index.d.ts
@@ -89,20 +89,8 @@ export interface ParseOptions {
 	readonly parseBooleans?: boolean;
 }
 
-export interface ParsedQuery {
-	[key: string]: string | string[] | null | undefined;
-}
-
-export interface ParsedQueryWithBooleans {
-	[key: string]: string | boolean | Array<string | boolean> | null | undefined;
-}
-
-export interface ParsedQueryWithNumbers {
-	[key: string]: string | number | Array<string | number> | null | undefined;
-}
-
-export interface ParsedQueryWithBooleansAndNumbers {
-	[key: string]: string | number | boolean | Array<string | number | boolean> | null | undefined;
+export interface ParsedQuery<T = string> {
+	[key: string]: T | Array<T> | null | undefined;
 }
 
 /**
@@ -112,9 +100,9 @@ The returned object is created with [`Object.create(null)`](https://developer.mo
 
 @param query - The query string to parse.
 */
-export function parse(query: string, options: {parseBooleans: true, parseNumbers: true} & ParseOptions): ParsedQueryWithBooleansAndNumbers;
-export function parse(query: string, options: {parseBooleans: true} & ParseOptions): ParsedQueryWithBooleans;
-export function parse(query: string, options: {parseNumbers: true} & ParseOptions): ParsedQueryWithNumbers;
+export function parse(query: string, options: {parseBooleans: true, parseNumbers: true} & ParseOptions): ParsedQuery<string | boolean | number>;
+export function parse(query: string, options: {parseBooleans: true} & ParseOptions): ParsedQuery<string | boolean>;
+export function parse(query: string, options: {parseNumbers: true} & ParseOptions): ParsedQuery<string | number>;
 export function parse(query: string, options?: ParseOptions): ParsedQuery;
 
 export interface ParsedUrl {

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -51,11 +51,14 @@ expectType<queryString.ParsedQuery>(
 expectType<queryString.ParsedQuery>(
 	queryString.parse('?foo=bar', {arrayFormat: 'comma'})
 );
-expectType<queryString.ParsedQuery>(
+expectType<queryString.ParsedQueryWithNumbers>(
 	queryString.parse('?foo=1', {parseNumbers: true})
 );
-expectType<queryString.ParsedQuery>(
+expectType<queryString.ParsedQueryWithBooleans>(
 	queryString.parse('?foo=true', {parseBooleans: true})
+);
+expectType<queryString.ParsedQueryWithBooleansAndNumbers>(
+	queryString.parse('?foo=true', {parseBooleans: true, parseNumbers: true})
 );
 
 // Parse URL

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -51,13 +51,13 @@ expectType<queryString.ParsedQuery>(
 expectType<queryString.ParsedQuery>(
 	queryString.parse('?foo=bar', {arrayFormat: 'comma'})
 );
-expectType<queryString.ParsedQueryWithNumbers>(
+expectType<queryString.ParsedQuery<string | number>>(
 	queryString.parse('?foo=1', {parseNumbers: true})
 );
-expectType<queryString.ParsedQueryWithBooleans>(
+expectType<queryString.ParsedQuery<string | boolean>>(
 	queryString.parse('?foo=true', {parseBooleans: true})
 );
-expectType<queryString.ParsedQueryWithBooleansAndNumbers>(
+expectType<queryString.ParsedQuery<string | boolean | number>>(
 	queryString.parse('?foo=true', {parseBooleans: true, parseNumbers: true})
 );
 


### PR DESCRIPTION
We need to return different versions of `ParsedQuery` based on the values of `parseBooleans` and `parseNumbers`.

Not sure about the naming. A bit verbose, but....

Fixes #184

@alecf @felixoi will this work for you?