### PR TITLE
Fix using the `parseNumbers` and `parseBooleans` options together

### DIFF
--- a/index.js
+++ b/index.js
@@ -204,9 +204,7 @@ function parse(input, options) {
 
 		if (options.parseNumbers && !Number.isNaN(Number(value))) {
 			value = Number(value);
-		}
-
-		if (options.parseBooleans && value !== null && (value.toLowerCase() === 'true' || value.toLowerCase() === 'false')) {
+		} else if (options.parseBooleans && value !== null && (value.toLowerCase() === 'true' || value.toLowerCase() === 'false')) {
 			value = value.toLowerCase() === 'true';
 		}
 

--- a/test/parse.js
+++ b/test/parse.js
@@ -255,6 +255,6 @@ test('boolean value returns as boolean if option is set', t => {
 });
 
 test('boolean value returns as boolean and number value as number if both options are set', t => {
-	t.deepEqual(queryString.parse('foo=true,bar=1.12', {parseNumbers: true, parseBooleans: true}), {foo: true, bar: 1.12});
+	t.deepEqual(queryString.parse('foo=true&bar=1.12', {parseNumbers: true, parseBooleans: true}), {foo: true, bar: 1.12});
 	t.deepEqual(queryString.parse('foo=16.32&bar=false', {parseNumbers: true, parseBooleans: true}), {foo: 16.32, bar: false});
 });

--- a/test/parse.js
+++ b/test/parse.js
@@ -253,3 +253,8 @@ test('boolean value returns as boolean if option is set', t => {
 	t.deepEqual(queryString.parse('foo=true', {parseBooleans: true}), {foo: true});
 	t.deepEqual(queryString.parse('foo=false&bar=true', {parseBooleans: true}), {foo: false, bar: true});
 });
+
+test('boolean value returns as boolean and number value as number if both options are set', t => {
+	t.deepEqual(queryString.parse('foo=true,bar=1.12', {parseNumbers: true, parseBooleans: true}), {foo: true, bar: 1.12});
+	t.deepEqual(queryString.parse('foo=16.32&bar=false', {parseNumbers: true, parseBooleans: true}), {foo: 16.32, bar: false});
+});


### PR DESCRIPTION
Not tested but I expect it to work. Problem was that if it's was a number, value was set to number already and it still checked if it's a boolean.

Fixes #186