### PR TITLE
Ensure empty string & spaces are parsed as string when `parseNumber: true`

### DIFF
--- a/index.js
+++ b/index.js
@@ -202,7 +202,7 @@ function parse(input, options) {
 		// http://w3.org/TR/2012/WD-url-20120524/#collect-url-parameters
 		value = value === undefined ? null : decode(value, options);
 
-		if (options.parseNumbers && !Number.isNaN(Number(value))) {
+		if (options.parseNumbers && !Number.isNaN(Number(value)) && (typeof value === 'string' && value.trim() !== '')) {
 			value = Number(value);
 		} else if (options.parseBooleans && value !== null && (value.toLowerCase() === 'true' || value.toLowerCase() === 'false')) {
 			value = value.toLowerCase() === 'true';

--- a/test/parse.js
+++ b/test/parse.js
@@ -243,6 +243,7 @@ test('NaN value returns as string if option is set', t => {
 	t.deepEqual(queryString.parse('foo=null', {parseNumbers: true}), {foo: 'null'});
 	t.deepEqual(queryString.parse('foo=undefined', {parseNumbers: true}), {foo: 'undefined'});
 	t.deepEqual(queryString.parse('foo=100a&bar=100', {parseNumbers: true}), {foo: '100a', bar: 100});
+	t.deepEqual(queryString.parse('foo=   &bar=', {parseNumbers: true}), {foo: '   ', bar: ''});
 });
 
 test('boolean value returns as string by default', t => {


### PR DESCRIPTION
fix #194 