### PR TITLE
Add option to skip null and undefined values in stringify

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -100,9 +100,9 @@ The returned object is created with [`Object.create(null)`](https://developer.mo
 
 @param query - The query string to parse.
 */
-export function parse(query: string, options: {parseBooleans: true, parseNumbers: true} & ParseOptions): ParsedQuery<string | boolean | number>;
-export function parse(query: string, options: {parseBooleans: true} & ParseOptions): ParsedQuery<string | boolean>;
-export function parse(query: string, options: {parseNumbers: true} & ParseOptions): ParsedQuery<string | number>;
+export function parse(query: string, options: { parseBooleans: true, parseNumbers: true } & ParseOptions): ParsedQuery<string | boolean | number>;
+export function parse(query: string, options: { parseBooleans: true } & ParseOptions): ParsedQuery<string | boolean>;
+export function parse(query: string, options: { parseNumbers: true } & ParseOptions): ParsedQuery<string | number>;
 export function parse(query: string, options?: ParseOptions): ParsedQuery;
 
 export interface ParsedUrl {
@@ -192,13 +192,33 @@ export interface StringifyOptions {
 	```
 	*/
 	readonly sort?: ((itemLeft: string, itemRight: string) => number) | false;
+
+	/**
+	Takes a boolean which decides whether or not `undefined` and `null` values should be skipped when stringify-ing.
+
+	@default false
+
+	@example
+	```
+	queryString.stringify({ a: 'ja', b: undefined, c: null, d: 'vielsker' }, {
+		skipNullAndUndefined: true,
+	});
+	// => 'a=ja&d=vielsker'
+
+	queryString.stringify({ a: undefined, b: null }, {
+		skipNullAndUndefined: true,
+	});
+	// => ''
+	```
+	*/
+	readonly skipNullAndUndefined?: boolean;
 }
 
 /**
 Stringify an object into a query string and sort the keys.
 */
 export function stringify(
-	object: {[key: string]: any},
+	object: { [key: string]: any },
 	options?: StringifyOptions
 ): string;
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -200,15 +200,15 @@ export interface StringifyOptions {
 
 	@example
 	```
-	queryString.stringify({ a: 'ja', b: undefined, c: null, d: 'vielsker' }, {
+	queryString.stringify({a: 1, b: undefined, c: null, d: 4}, {
 		skipNullAndUndefined: true,
 	});
-	// => 'a=ja&d=vielsker'
+	//=> 'a=1&d=4'
 
-	queryString.stringify({ a: undefined, b: null }, {
+	queryString.stringify({a: undefined, b: null}, {
 		skipNullAndUndefined: true,
 	});
-	// => ''
+	//=> ''
 	```
 	*/
 	readonly skipNullAndUndefined?: boolean;

--- a/index.js
+++ b/index.js
@@ -244,7 +244,7 @@ exports.stringify = (input, options) => {
 
 	const formatter = encoderForArrayFormat(options);
 
-	const	object	=	Object.assign({},	input);
+	const object = Object.assign({}, input);
 
 	if (options.skipNullAndUndefined) {
 		for (const key of Object.keys(object)) {

--- a/index.js
+++ b/index.js
@@ -231,8 +231,8 @@ function parse(input, options) {
 exports.extract = extract;
 exports.parse = parse;
 
-exports.stringify = (object, options) => {
-	if (!object) {
+exports.stringify = (input, options) => {
+	if (!input) {
 		return '';
 	}
 
@@ -243,6 +243,8 @@ exports.stringify = (object, options) => {
 	}, options);
 
 	const formatter = encoderForArrayFormat(options);
+
+	const	object	=	Object.assign({},	input);
 
 	if (options.skipNullAndUndefined) {
 		for (const key of Object.keys(object)) {

--- a/index.js
+++ b/index.js
@@ -245,8 +245,8 @@ exports.stringify = (object, options) => {
 	const formatter = encoderForArrayFormat(options);
 
 	if (options.skipNullAndUndefined) {
-		for (const [key, value] of Object.entries(object)) {
-			if (value === undefined || value === null) {
+		for (const key of Object.keys(object)) {
+			if (object[key] === undefined || object[key] === null) {
 				delete object[key];
 			}
 		}

--- a/index.js
+++ b/index.js
@@ -243,6 +243,15 @@ exports.stringify = (object, options) => {
 	}, options);
 
 	const formatter = encoderForArrayFormat(options);
+
+	if (options.skipNullAndUndefined) {
+		for (const [key, value] of Object.entries(object)) {
+			if (value === undefined || value === null) {
+				delete object[key];
+			}
+		}
+	}
+
 	const keys = Object.keys(object);
 
 	if (options.sort !== false) {

--- a/readme.md
+++ b/readme.md
@@ -202,25 +202,26 @@ queryString.stringify({b: 1, c: 2, a: 3}, {sort: false});
 //=> 'b=1&c=2&a=3'
 ```
 
+If omitted, keys are sorted using `Array#sort()`, which means, converting them to strings and comparing strings in Unicode code point order.
+
 ##### skipNullAndUndefined
 
-Type: `boolean`
+Type: `boolean`<br>
+Default: `false`
 
 ```js
-queryString.stringify({ a: 'ja', b: undefined, c: null, d: 'vielsker' }, {
+queryString.stringify({a: 1, b: undefined, c: null, d: 4}, {
 	skipNullAndUndefined: true,
 });
-// => 'a=ja&d=vielsker'
+//=> 'a=1&d=4'
 ```
 
 ```js
-queryString.stringify({ a: undefined, b: null }, {
+queryString.stringify({a: undefined, b: null}, {
 	skipNullAndUndefined: true,
 });
-// => ''
+//=> ''
 ```
-
-If omitted, keys are sorted using `Array#sort()`, which means, converting them to strings and comparing strings in Unicode code point order.
 
 ### .extract(string)
 
@@ -269,8 +270,6 @@ queryString.stringify({color: ['taupe', 'chartreuse'], id: '515'});
 
 ## Falsy values
 
-This behaviour can be altered by using the `skipNullAndUndefined` setting in the options variable. With this set to `true`, `null` and `undefined` will return in no key being generated in the output.
-
 Sometimes you want to unset a key, or maybe just make it present without assigning a value to it. Here is how falsy values are stringified:
 
 ```js
@@ -283,6 +282,8 @@ queryString.stringify({foo: null});
 queryString.stringify({foo: undefined});
 //=> ''
 ```
+
+Note: This behaviour can be changed with the `skipNullAndUndefined` option.
 
 
 ---

--- a/readme.md
+++ b/readme.md
@@ -202,6 +202,24 @@ queryString.stringify({b: 1, c: 2, a: 3}, {sort: false});
 //=> 'b=1&c=2&a=3'
 ```
 
+##### skipNullAndUndefined
+
+Type: `boolean`
+
+```js
+queryString.stringify({ a: 'ja', b: undefined, c: null, d: 'vielsker' }, {
+	skipNullAndUndefined: true,
+});
+// => 'a=ja&d=vielsker'
+```
+
+```js
+queryString.stringify({ a: undefined, b: null }, {
+	skipNullAndUndefined: true,
+});
+// => ''
+```
+
 If omitted, keys are sorted using `Array#sort()`, which means, converting them to strings and comparing strings in Unicode code point order.
 
 ### .extract(string)
@@ -250,6 +268,8 @@ queryString.stringify({color: ['taupe', 'chartreuse'], id: '515'});
 
 
 ## Falsy values
+
+This behaviour can be altered by using the `skipNullAndUndefined` setting in the options variable. With this set to `true`, `null` and `undefined` will return in no key being generated in the output.
 
 Sometimes you want to unset a key, or maybe just make it present without assigning a value to it. Here is how falsy values are stringified:
 

--- a/test/stringify.js
+++ b/test/stringify.js
@@ -193,3 +193,32 @@ test('should disable sorting', t => {
 		sort: false
 	}), 'c=foo&b=bar&a=baz');
 });
+
+test('should ignore null when skipNullAndUndefined is set', t => {
+	t.is(queryString.stringify({
+		a: 'ja',
+		b: null,
+		c: 'vielsker'
+	}, {
+		skipNullAndUndefined: true
+	}), 'a=ja&c=vielsker');
+});
+
+test('should ignore undefined when skipNullAndUndefined is set', t => {
+	t.is(queryString.stringify({
+		a: 'ja',
+		b: undefined,
+		c: 'vielsker'
+	}, {
+		skipNullAndUndefined: true
+	}), 'a=ja&c=vielsker');
+});
+
+test('should ignore both null and undefined when skipNullAndUndefined is set', t => {
+	t.is(queryString.stringify({
+		a: undefined,
+		b: null
+	}, {
+		skipNullAndUndefined: true
+	}), '');
+});

--- a/test/stringify.js
+++ b/test/stringify.js
@@ -196,22 +196,22 @@ test('should disable sorting', t => {
 
 test('should ignore null when skipNullAndUndefined is set', t => {
 	t.is(queryString.stringify({
-		a: 'ja',
+		a: 1,
 		b: null,
-		c: 'vielsker'
+		c: 3
 	}, {
 		skipNullAndUndefined: true
-	}), 'a=ja&c=vielsker');
+	}), 'a=1&c=3');
 });
 
 test('should ignore undefined when skipNullAndUndefined is set', t => {
 	t.is(queryString.stringify({
-		a: 'ja',
+		a: 1,
 		b: undefined,
-		c: 'vielsker'
+		c: 3
 	}, {
 		skipNullAndUndefined: true
-	}), 'a=ja&c=vielsker');
+	}), 'a=1&c=3');
 });
 
 test('should ignore both null and undefined when skipNullAndUndefined is set', t => {


### PR DESCRIPTION
You can now pass an option called `skipNullAndUndefined` to the options
object in stringify to prevent the generator from generating keys for
those keys.

Fixes #196.