### PR TITLE
Bug: Raises hard error in older versions of Firefox

### DIFF
--- a/index.js
+++ b/index.js
@@ -195,7 +195,7 @@ function parse(input, options) {
 		return ret;
 	}
 
-	for (const param of input.split('&')) {
+	for (let param of input.split('&')) {
 		let [key, value] = splitOnFirst(param.replace(/\+/g, ' '), '=');
 
 		// Missing `=` should be `null`:


### PR DESCRIPTION
In older browsers (I found it broken in Firefox 48.0.2), this would raise the following error: 

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Missing_initializer_in_const

Using `let` instead prevents this error since the variable is overwritten each iteration.