### PR TITLE
Added option to skip nulls, undefined, and empty strings for stringify

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -192,6 +192,64 @@ export interface StringifyOptions {
 	```
 	*/
 	readonly sort?: ((itemLeft: string, itemRight: string) => number) | false;
+
+	/**
+	Takes a boolean which decides if 'undefined' values should be skipped during stringify
+
+	@default true
+
+	@example
+	```
+	queryString.stringify({a: undefined, b: null, c: 'one'}, {skipUndefined=true});
+	//=> 'b&c=one'
+	```
+	*/
+	readonly skipUndefined?: boolean
+
+	/**
+	Takes a boolean which decides if 'null' values should be skipped during stringify
+
+	@default false
+
+	@example
+	```
+	queryString.stringify({a: null, b: 'one'}, {skipNulls=true});
+	//=>  'b=one'
+	```
+	*/
+	readonly skipNulls?: boolean
+
+	/**
+	Takes a boolean which decides if 'undefined' and 'null' values should be skipped during stringify
+
+	@default false
+
+	@example
+	```
+	queryString.stringify({a: undefined, b: null, c: 'one'}, {skipNullAndUndefined=true});
+	//=> 'c=one'
+
+	queryString.stringify({a: undefined, b: null}, {skipNullAndUndefined=true});
+	//=> ''
+	```
+	*/
+	readonly skipNullAndUndefined?: boolean
+
+	/**
+	Takes a boolean which decides if empty string values should be skipped during stringify
+
+	@default false
+
+	@example
+	```
+	queryString.stringify({a: null, b: '', c: 'one'}, {skipEmptyStrings=true});
+	//=> a&c=one
+
+	queryString.stringify({a: '', b: ['one', '', 'three']}, {skipEmptyStrings=true});
+	//=> 'b=one&b=three'
+	```
+	*/
+	readonly skipEmptyStrings?: boolean
 }
 
 /**

--- a/index.js
+++ b/index.js
@@ -9,11 +9,23 @@ function encoderForArrayFormat(options) {
 			return key => (result, value) => {
 				const index = result.length;
 				if (value === undefined) {
-					return result;
+					if (options.skipNullAndUndefined || options.skipUndefined) {
+						return result;
+					}
+
+					return [...result, [encode(key, options), '[', index, ']'].join('')];
 				}
 
 				if (value === null) {
+					if (options.skipNullAndUndefined || options.skipNulls) {
+						return result;
+					}
+
 					return [...result, [encode(key, options), '[', index, ']'].join('')];
+				}
+
+				if (value === '' && options.skipEmptyStrings) {
+					return result;
 				}
 
 				return [
@@ -25,11 +37,23 @@ function encoderForArrayFormat(options) {
 		case 'bracket':
 			return key => (result, value) => {
 				if (value === undefined) {
-					return result;
+					if (options.skipNullAndUndefined || options.skipUndefined) {
+						return result;
+					}
+
+					return [...result, [encode(key, options), '[]'].join('')];
 				}
 
 				if (value === null) {
+					if (options.skipNullAndUndefined || options.skipNulls) {
+						return result;
+					}
+
 					return [...result, [encode(key, options), '[]'].join('')];
+				}
+
+				if (value === '' && options.skipEmptyStrings) {
+					return result;
 				}
 
 				return [...result, [encode(key, options), '[]=', encode(value, options)].join('')];
@@ -51,11 +75,23 @@ function encoderForArrayFormat(options) {
 		default:
 			return key => (result, value) => {
 				if (value === undefined) {
-					return result;
+					if (options.skipNullAndUndefined || options.skipUndefined) {
+						return result;
+					}
+
+					return [...result, encode(key, options)];
 				}
 
 				if (value === null) {
+					if (options.skipNullAndUndefined || options.skipNulls) {
+						return result;
+					}
+
 					return [...result, encode(key, options)];
+				}
+
+				if (value === '' && options.skipEmptyStrings) {
+					return result;
 				}
 
 				return [...result, [encode(key, options), '=', encode(value, options)].join('')];
@@ -253,7 +289,8 @@ exports.stringify = (object, options) => {
 	options = Object.assign({
 		encode: true,
 		strict: true,
-		arrayFormat: 'none'
+		arrayFormat: 'none',
+		skipUndefined: true
 	}, options);
 
 	const formatter = encoderForArrayFormat(options);
@@ -267,11 +304,25 @@ exports.stringify = (object, options) => {
 		const value = object[key];
 
 		if (value === undefined) {
-			return '';
+			if (options.skipNullAndUndefined || options.skipUndefined) {
+				return '';
+			}
+
+			return encode(key, options);
 		}
 
 		if (value === null) {
+			if (options.skipNullAndUndefined || options.skipNulls) {
+				return '';
+			}
+
 			return encode(key, options);
+		}
+
+		if (value === '') {
+			if (options.skipEmptyStrings) {
+				return '';
+			}
 		}
 
 		if (Array.isArray(value)) {

--- a/readme.md
+++ b/readme.md
@@ -204,6 +204,60 @@ queryString.stringify({b: 1, c: 2, a: 3}, {sort: false});
 
 If omitted, keys are sorted using `Array#sort()`, which means, converting them to strings and comparing strings in Unicode code point order.
 
+#### skipUndefined
+
+Type: `boolean`<br>
+Default: `true`
+
+```js
+queryString.stringify({a: undefined, b: null, c: 'one'}, {skipUndefined=true});
+//=> 'b&c=one'
+```
+
+Takes a boolean which decides if 'undefined' values should be skipped during stringify.
+
+#### skipNulls
+
+Type: `boolean`<br>
+Default: `false`
+
+```js
+queryString.stringify({a: null, b: 'one'}, {skipNulls=true});
+//=>  'b=one'
+```
+
+Takes a boolean which decides if 'null' values should be skipped during stringify.
+
+#### skipNullAndUndefined
+
+Type: `boolean`<br>
+Default: `false`
+
+```js
+queryString.stringify({a: undefined, b: null, c: 'one'}, {skipNullAndUndefined=true});
+//=> 'c=one'
+
+queryString.stringify({a: undefined, b: null}, {skipNullAndUndefined=true});
+//=> ''
+```
+
+Takes a boolean which decides if 'undefined' and 'null' values should be skipped during stringify.
+
+#### skipEmptyStrings
+
+Type: `boolean`<br>
+Default: `false`
+
+```js
+queryString.stringify({a: null, b: '', c: 'one'}, {skipEmptyStrings=true});
+//=> a&c=one
+
+queryString.stringify({a: '', b: ['one', '', 'three']}, {skipEmptyStrings=true});
+//=> 'b=one&b=three'
+```
+
+Takes a boolean which decides if empty string values should be skipped during stringify.
+
 ### .extract(string)
 
 Extract a query string from a URL that can be passed into `.parse()`.

--- a/test/stringify.js
+++ b/test/stringify.js
@@ -193,3 +193,87 @@ test('should disable sorting', t => {
 		sort: false
 	}), 'c=foo&b=bar&a=baz');
 });
+
+test('should remove null and undefined', t => {
+	t.is(queryString.stringify({
+		a: undefined,
+		b: null,
+		c: 'foo',
+		d: ['bar', null, 'baz', undefined]
+	}, {
+		skipNullAndUndefined: true
+	}), 'c=foo&d=bar&d=baz');
+});
+
+test('should remove nulls', t => {
+	t.is(queryString.stringify({
+		a: undefined,
+		b: null,
+		c: 'foo'
+	}, {
+		skipUndefined: false,
+		skipNulls: true
+	}), 'a&c=foo');
+});
+
+test('should remove undefined', t => {
+	t.is(queryString.stringify({
+		a: undefined,
+		b: null,
+		c: 'foo'
+	}, {
+		skipUndefined: true
+	}), 'b&c=foo');
+});
+
+test('should remove empty strings', t => {
+	t.is(queryString.stringify({
+		a: undefined,
+		b: '',
+		c: 'foo'
+	}, {
+		skipEmptyStrings: true
+	}), 'c=foo');
+});
+
+test('should remove empty strings array', t => {
+	t.is(queryString.stringify({
+		a: undefined,
+		b: '',
+		c: 'foo',
+		d: ['', 'foo', null, '', 'baz']
+	}, {
+		skipEmptyStrings: true
+	}), 'c=foo&d=foo&d&d=baz');
+});
+
+test('array stringify representation with array brackets skipping nulls and not skipping undefined', t => {
+	t.is(queryString.stringify({
+		foo: ['a', null, '', undefined],
+		bar: [null]
+	}, {
+		arrayFormat: 'bracket',
+		skipNulls: true,
+		skipUndefined: false
+	}), 'foo[]=a&foo[]=&foo[]');
+});
+
+test('array stringify representation with array brackets not skipping undefined', t => {
+	t.is(queryString.stringify({
+		foo: ['a', null, '', undefined],
+		bar: [null]
+	}, {
+		arrayFormat: 'bracket',
+		skipUndefined: false
+	}), 'bar[]&foo[]=a&foo[]&foo[]=&foo[]');
+});
+
+test('array stringify representation with array brackets skipping undefined and nulls', t => {
+	t.is(queryString.stringify({
+		foo: ['a', null, '', undefined],
+		bar: [null]
+	}, {
+		arrayFormat: 'bracket',
+		skipNullAndUndefined: true
+	}), 'foo[]=a&foo[]=');
+});


### PR DESCRIPTION
Added optional parameters to stringify

- skipUndefined: Skip or keep values that are undefined (Original behavior is default)
- skipNulls: Allows to skip or keep null values
- skipNullAndUndefined: Behavior of skipUndefined and skipNulls
- skipEmptyStrings: Skips values with empty strings

Fixes #196 