### PR TITLE
Only parse `+` to space when `decode` is true

### DIFF
--- a/index.js
+++ b/index.js
@@ -206,7 +206,7 @@ function parse(input, options) {
 	}
 
 	for (const param of input.split('&')) {
-		let [key, value] = splitOnFirst(param.replace(/\+/g, ' '), '=');
+		let [key, value] = splitOnFirst(options.decode ? param.replace(/\+/g, ' ') : param, '=');
 
 		// Missing `=` should be `null`:
 		// http://w3.org/TR/2012/WD-url-20120524/#collect-url-parameters

--- a/test/parse.js
+++ b/test/parse.js
@@ -75,6 +75,10 @@ test('handle `+` correctly', t => {
 	t.deepEqual(queryString.parse('foo+faz=bar+baz++'), {'foo faz': 'bar baz  '});
 });
 
+test('handle `+` correctly when not decoding', t => {
+	t.deepEqual(queryString.parse('foo+faz=bar+baz++', {decode: false}), {'foo+faz': 'bar+baz++'});
+});
+
 test('handle multiple of the same key', t => {
 	t.deepEqual(queryString.parse('foo=bar&foo=baz'), {foo: ['bar', 'baz']});
 });


### PR DESCRIPTION
The parsing of '+' to ' ' is a constant source of confusion in the query-string module. This is correct behavior, but I think it should only occur when decode is set to true. This is because this decoding isn't handled by the `decode-uri-component`, but it's being done manually in this project. See [this comment](https://github.com/sindresorhus/query-string/issues/119#issuecomment-533640064).

Fixes #119