### PR TITLE
Add option to skip keys with the value of `null` in `.stringify()`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -195,13 +195,16 @@ export interface StringifyOptions {
 
 	/**
 	Skip the key in stringify result if value is `null` or `undefined`.
+
 	@default false
+
 	@example
 	```
 	queryString.stringify({a: 1, b: undefined, c: null, d: 4}, {
 		skipNullAndUndefined: true,
 	});
 	//=> 'a=1&d=4'
+
 	queryString.stringify({a: undefined, b: null}, {
 		skipNullAndUndefined: true,
 	});

--- a/index.d.ts
+++ b/index.d.ts
@@ -224,5 +224,7 @@ export function stringify(
 
 /**
 Extract a query string from a URL that can be passed into `.parse()`.
+
+Note: This behaviour can be changed with the `skipNullAndUndefined` option.
 */
 export function extract(url: string): string;

--- a/index.d.ts
+++ b/index.d.ts
@@ -201,17 +201,17 @@ export interface StringifyOptions {
 	@example
 	```
 	queryString.stringify({a: 1, b: undefined, c: null, d: 4}, {
-		skipNullAndUndefined: true,
+		skipNull: true,
 	});
 	//=> 'a=1&d=4'
 
 	queryString.stringify({a: undefined, b: null}, {
-		skipNullAndUndefined: true,
+		skipNull: true,
 	});
 	//=> ''
 	```
 	*/
-	readonly skipNullAndUndefined?: boolean;
+	readonly skipNull?: boolean;
 }
 
 /**
@@ -225,6 +225,6 @@ export function stringify(
 /**
 Extract a query string from a URL that can be passed into `.parse()`.
 
-Note: This behaviour can be changed with the `skipNullAndUndefined` option.
+Note: This behaviour can be changed with the `skipNull` option.
 */
 export function extract(url: string): string;

--- a/index.d.ts
+++ b/index.d.ts
@@ -203,7 +203,7 @@ export interface StringifyOptions {
 	@example
 	```
 	queryString.stringify({a: 1, b: undefined, c: null, d: 4}, {
-		skipNull: true,
+		skipNull: true
 	});
 	//=> 'a=1&d=4'
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -192,6 +192,23 @@ export interface StringifyOptions {
 	```
 	*/
 	readonly sort?: ((itemLeft: string, itemRight: string) => number) | false;
+
+	/**
+	Skip the key in stringify result if value is `null` or `undefined`.
+	@default false
+	@example
+	```
+	queryString.stringify({a: 1, b: undefined, c: null, d: 4}, {
+		skipNullAndUndefined: true,
+	});
+	//=> 'a=1&d=4'
+	queryString.stringify({a: undefined, b: null}, {
+		skipNullAndUndefined: true,
+	});
+	//=> ''
+	```
+	*/
+	readonly skipNullAndUndefined?: boolean;
 }
 
 /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -194,7 +194,9 @@ export interface StringifyOptions {
 	readonly sort?: ((itemLeft: string, itemRight: string) => number) | false;
 
 	/**
-	Skip the key in stringify result if value is `null` or `undefined`.
+	Skip keys with `null` as the value.
+	
+	Note that keys with `undefined` as the value are always skipped.
 
 	@default false
 
@@ -206,7 +208,7 @@ export interface StringifyOptions {
 	//=> 'a=1&d=4'
 
 	queryString.stringify({a: undefined, b: null}, {
-		skipNull: true,
+		skipNull: true
 	});
 	//=> ''
 	```

--- a/index.js
+++ b/index.js
@@ -260,14 +260,14 @@ exports.stringify = (object, options) => {
 
 	const objectCopy = Object.assign({}, object);
 	if (options.skipNullAndUndefined) {
-		for (const key of Object.keys(objectCpy)) {
-			if (objectCpy[key] === undefined || objectCpy[key] === null) {
-				delete objectCpy[key];
+		for (const key of Object.keys(objectCopy)) {
+			if (objectCopy[key] === undefined || objectCopy[key] === null) {
+				delete objectCopy[key];
 			}
 		}
 	}
 
-	const keys = Object.keys(objectCpy);
+	const keys = Object.keys(objectCopy);
 
 	if (options.sort !== false) {
 		keys.sort(options.sort);

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ function encoderForArrayFormat(options) {
 		case 'index':
 			return key => (result, value) => {
 				const index = result.length;
-				if (value === undefined || (options.skipNullAndUndefined && value === null)) {
+				if (value === undefined || (options.skipNull && value === null)) {
 					return result;
 				}
 
@@ -24,7 +24,7 @@ function encoderForArrayFormat(options) {
 
 		case 'bracket':
 			return key => (result, value) => {
-				if (value === undefined || (options.skipNullAndUndefined && value === null)) {
+				if (value === undefined || (options.skipNull && value === null)) {
 					return result;
 				}
 
@@ -50,7 +50,7 @@ function encoderForArrayFormat(options) {
 
 		default:
 			return key => (result, value) => {
-				if (value === undefined || (options.skipNullAndUndefined && value === null)) {
+				if (value === undefined || (options.skipNull && value === null)) {
 					return result;
 				}
 
@@ -259,7 +259,7 @@ exports.stringify = (object, options) => {
 	const formatter = encoderForArrayFormat(options);
 
 	const objectCopy = Object.assign({}, object);
-	if (options.skipNullAndUndefined) {
+	if (options.skipNull) {
 		for (const key of Object.keys(objectCopy)) {
 			if (objectCopy[key] === undefined || objectCopy[key] === null) {
 				delete objectCopy[key];

--- a/index.js
+++ b/index.js
@@ -258,7 +258,7 @@ exports.stringify = (object, options) => {
 
 	const formatter = encoderForArrayFormat(options);
 
-	const objectCpy = Object.assign({}, object);
+	const objectCopy = Object.assign({}, object);
 	if (options.skipNullAndUndefined) {
 		for (const key of Object.keys(objectCpy)) {
 			if (objectCpy[key] === undefined || objectCpy[key] === null) {

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ function encoderForArrayFormat(options) {
 		case 'index':
 			return key => (result, value) => {
 				const index = result.length;
-				if (value === undefined) {
+				if (value === undefined || (options.skipNullAndUndefined && value === null)) {
 					return result;
 				}
 
@@ -24,7 +24,7 @@ function encoderForArrayFormat(options) {
 
 		case 'bracket':
 			return key => (result, value) => {
-				if (value === undefined) {
+				if (value === undefined || (options.skipNullAndUndefined && value === null)) {
 					return result;
 				}
 
@@ -36,12 +36,12 @@ function encoderForArrayFormat(options) {
 			};
 
 		case 'comma':
-			return key => (result, value, index) => {
+			return key => (result, value) => {
 				if (value === null || value === undefined || value.length === 0) {
 					return result;
 				}
 
-				if (index === 0) {
+				if (result.length === 0) {
 					return [[encode(key, options), '=', encode(value, options)].join('')];
 				}
 
@@ -50,7 +50,7 @@ function encoderForArrayFormat(options) {
 
 		default:
 			return key => (result, value) => {
-				if (value === undefined) {
+				if (value === undefined || (options.skipNullAndUndefined && value === null)) {
 					return result;
 				}
 
@@ -257,7 +257,17 @@ exports.stringify = (object, options) => {
 	}, options);
 
 	const formatter = encoderForArrayFormat(options);
-	const keys = Object.keys(object);
+
+	const objectCpy = Object.assign({}, object);
+	if (options.skipNullAndUndefined) {
+		for (const key of Object.keys(objectCpy)) {
+			if (objectCpy[key] === undefined || objectCpy[key] === null) {
+				delete objectCpy[key];
+			}
+		}
+	}
+
+	const keys = Object.keys(objectCpy);
 
 	if (options.sort !== false) {
 		keys.sort(options.sort);

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -22,7 +22,7 @@ expectType<string>(queryString.stringify({foo: 'bar'}, {arrayFormat: 'index'}));
 expectType<string>(queryString.stringify({foo: 'bar'}, {arrayFormat: 'none'}));
 expectType<string>(queryString.stringify({foo: 'bar'}, {arrayFormat: 'comma'}));
 expectType<string>(queryString.stringify({foo: 'bar'}, {sort: false}));
-expectType<string>(queryString.stringify({foo: 'bar'}, {skipNullAndUndefined: true}));
+expectType<string>(queryString.stringify({foo: 'bar'}, {skipNull: true}));
 const order = ['c', 'a', 'b'];
 expectType<string>(
 	queryString.stringify(

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -22,6 +22,7 @@ expectType<string>(queryString.stringify({foo: 'bar'}, {arrayFormat: 'index'}));
 expectType<string>(queryString.stringify({foo: 'bar'}, {arrayFormat: 'none'}));
 expectType<string>(queryString.stringify({foo: 'bar'}, {arrayFormat: 'comma'}));
 expectType<string>(queryString.stringify({foo: 'bar'}, {sort: false}));
+expectType<string>(queryString.stringify({foo: 'bar'}, {skipNullAndUndefined: true}));
 const order = ['c', 'a', 'b'];
 expectType<string>(
 	queryString.stringify(

--- a/readme.md
+++ b/readme.md
@@ -206,21 +206,23 @@ If omitted, keys are sorted using `Array#sort()`, which means, converting them t
 
 ##### skipNull
 
-Skip the element in the stringify result if the value is `null` or `undefined`.
+Skip keys with `null` as the value.
+
+Note that keys with `undefined` as the value are always skipped.
 
 Type: `boolean`<br>
 Default: `false`
 
 ```js
 queryString.stringify({a: 1, b: undefined, c: null, d: 4}, {
-	skipNull: true,
+	skipNull: true
 });
 //=> 'a=1&d=4'
 ```
 
 ```js
 queryString.stringify({a: undefined, b: null}, {
-	skipNull: true,
+	skipNull: true
 });
 //=> ''
 ```

--- a/readme.md
+++ b/readme.md
@@ -204,7 +204,7 @@ queryString.stringify({b: 1, c: 2, a: 3}, {sort: false});
 
 If omitted, keys are sorted using `Array#sort()`, which means, converting them to strings and comparing strings in Unicode code point order.
 
-##### skipNullAndUndefined
+##### skipNull
 
 Skip the element in the stringify result if the value is `null` or `undefined`.
 
@@ -213,14 +213,14 @@ Default: `false`
 
 ```js
 queryString.stringify({a: 1, b: undefined, c: null, d: 4}, {
-	skipNullAndUndefined: true,
+	skipNull: true,
 });
 //=> 'a=1&d=4'
 ```
 
 ```js
 queryString.stringify({a: undefined, b: null}, {
-	skipNullAndUndefined: true,
+	skipNull: true,
 });
 //=> ''
 ```
@@ -229,7 +229,7 @@ queryString.stringify({a: undefined, b: null}, {
 
 Extract a query string from a URL that can be passed into `.parse()`.
 
-Note: This behaviour can be changed with the `skipNullAndUndefined` option.
+Note: This behaviour can be changed with the `skipNull` option.
 
 ### .parseUrl(string, options?)
 

--- a/readme.md
+++ b/readme.md
@@ -206,7 +206,7 @@ If omitted, keys are sorted using `Array#sort()`, which means, converting them t
 
 ##### skipNullAndUndefined
 
-Skip the key in stringify result if value is `null` or `undefined`.
+Skip the element in the stringify result if the value is `null` or `undefined`.
 
 Type: `boolean`<br>
 Default: `false`

--- a/readme.md
+++ b/readme.md
@@ -204,9 +204,32 @@ queryString.stringify({b: 1, c: 2, a: 3}, {sort: false});
 
 If omitted, keys are sorted using `Array#sort()`, which means, converting them to strings and comparing strings in Unicode code point order.
 
+##### skipNullAndUndefined
+
+Skip the key in stringify result if value is `null` or `undefined`.
+
+Type: `boolean`<br>
+Default: `false`
+
+```js
+queryString.stringify({a: 1, b: undefined, c: null, d: 4}, {
+	skipNullAndUndefined: true,
+});
+//=> 'a=1&d=4'
+```
+
+```js
+queryString.stringify({a: undefined, b: null}, {
+	skipNullAndUndefined: true,
+});
+//=> ''
+```
+
 ### .extract(string)
 
 Extract a query string from a URL that can be passed into `.parse()`.
+
+Note: This behaviour can be changed with the `skipNullAndUndefined` option.
 
 ### .parseUrl(string, options?)
 

--- a/test/stringify.js
+++ b/test/stringify.js
@@ -128,7 +128,7 @@ test('array stringify representation with array commas', t => {
 
 test('array stringify representation with array commas and null value', t => {
 	t.is(queryString.stringify({
-		foo: ['a', null, ''],
+		foo: [null, 'a', null, ''],
 		bar: [null]
 	}, {
 		arrayFormat: 'comma'
@@ -192,4 +192,67 @@ test('should disable sorting', t => {
 	}, {
 		sort: false
 	}), 'c=foo&b=bar&a=baz');
+});
+
+test('should ignore null when skipNullAndUndefined is set', t => {
+	t.is(queryString.stringify({
+		a: 1,
+		b: null,
+		c: 3
+	}, {
+		skipNullAndUndefined: true
+	}), 'a=1&c=3');
+});
+
+test('should ignore undefined when skipNullAndUndefined is set', t => {
+	t.is(queryString.stringify({
+		a: 1,
+		b: undefined,
+		c: 3
+	}, {
+		skipNullAndUndefined: true
+	}), 'a=1&c=3');
+});
+
+test('should ignore both null and undefined when skipNullAndUndefined is set', t => {
+	t.is(queryString.stringify({
+		a: undefined,
+		b: null
+	}, {
+		skipNullAndUndefined: true
+	}), '');
+});
+
+test('should ignore both null and undefined when skipNullAndUndefined is set for arrayFormat', t => {
+	t.is(queryString.stringify({
+		a: [undefined, null, 1, undefined, 2, null],
+		b: null,
+		c: 1
+	}, {
+		skipNullAndUndefined: true
+	}), 'a=1&a=2&c=1');
+	t.is(queryString.stringify({
+		a: [undefined, null, 1, undefined, 2, null],
+		b: null,
+		c: 1
+	}, {
+		skipNullAndUndefined: true,
+		arrayFormat: 'bracket'
+	}), 'a[]=1&a[]=2&c=1');
+	t.is(queryString.stringify({
+		a: [undefined, null, 1, undefined, 2, null],
+		b: null,
+		c: 1
+	}, {
+		skipNullAndUndefined: true,
+		arrayFormat: 'comma'
+	}), 'a=1,2&c=1');
+	t.is(queryString.stringify({
+		a: [undefined, null, 1, undefined, 2, null],
+		b: null,
+		c: 1
+	}, {
+		skipNullAndUndefined: true,
+		arrayFormat: 'index'
+	}), 'a[0]=1&a[1]=2&c=1');
 });

--- a/test/stringify.js
+++ b/test/stringify.js
@@ -231,6 +231,7 @@ test('should ignore both null and undefined when skipNullAndUndefined is set for
 	}, {
 		skipNullAndUndefined: true
 	}), 'a=1&a=2&c=1');
+
 	t.is(queryString.stringify({
 		a: [undefined, null, 1, undefined, 2, null],
 		b: null,
@@ -239,6 +240,7 @@ test('should ignore both null and undefined when skipNullAndUndefined is set for
 		skipNullAndUndefined: true,
 		arrayFormat: 'bracket'
 	}), 'a[]=1&a[]=2&c=1');
+
 	t.is(queryString.stringify({
 		a: [undefined, null, 1, undefined, 2, null],
 		b: null,
@@ -247,6 +249,7 @@ test('should ignore both null and undefined when skipNullAndUndefined is set for
 		skipNullAndUndefined: true,
 		arrayFormat: 'comma'
 	}), 'a=1,2&c=1');
+
 	t.is(queryString.stringify({
 		a: [undefined, null, 1, undefined, 2, null],
 		b: null,

--- a/test/stringify.js
+++ b/test/stringify.js
@@ -194,42 +194,42 @@ test('should disable sorting', t => {
 	}), 'c=foo&b=bar&a=baz');
 });
 
-test('should ignore null when skipNullAndUndefined is set', t => {
+test('should ignore null when skipNull is set', t => {
 	t.is(queryString.stringify({
 		a: 1,
 		b: null,
 		c: 3
 	}, {
-		skipNullAndUndefined: true
+		skipNull: true
 	}), 'a=1&c=3');
 });
 
-test('should ignore undefined when skipNullAndUndefined is set', t => {
+test('should ignore undefined when skipNull is set', t => {
 	t.is(queryString.stringify({
 		a: 1,
 		b: undefined,
 		c: 3
 	}, {
-		skipNullAndUndefined: true
+		skipNull: true
 	}), 'a=1&c=3');
 });
 
-test('should ignore both null and undefined when skipNullAndUndefined is set', t => {
+test('should ignore both null and undefined when skipNull is set', t => {
 	t.is(queryString.stringify({
 		a: undefined,
 		b: null
 	}, {
-		skipNullAndUndefined: true
+		skipNull: true
 	}), '');
 });
 
-test('should ignore both null and undefined when skipNullAndUndefined is set for arrayFormat', t => {
+test('should ignore both null and undefined when skipNull is set for arrayFormat', t => {
 	t.is(queryString.stringify({
 		a: [undefined, null, 1, undefined, 2, null],
 		b: null,
 		c: 1
 	}, {
-		skipNullAndUndefined: true
+		skipNull: true
 	}), 'a=1&a=2&c=1');
 
 	t.is(queryString.stringify({
@@ -237,7 +237,7 @@ test('should ignore both null and undefined when skipNullAndUndefined is set for
 		b: null,
 		c: 1
 	}, {
-		skipNullAndUndefined: true,
+		skipNull: true,
 		arrayFormat: 'bracket'
 	}), 'a[]=1&a[]=2&c=1');
 
@@ -246,7 +246,7 @@ test('should ignore both null and undefined when skipNullAndUndefined is set for
 		b: null,
 		c: 1
 	}, {
-		skipNullAndUndefined: true,
+		skipNull: true,
 		arrayFormat: 'comma'
 	}), 'a=1,2&c=1');
 
@@ -255,7 +255,7 @@ test('should ignore both null and undefined when skipNullAndUndefined is set for
 		b: null,
 		c: 1
 	}, {
-		skipNullAndUndefined: true,
+		skipNull: true,
 		arrayFormat: 'index'
 	}), 'a[0]=1&a[1]=2&c=1');
 });


### PR DESCRIPTION
Follow up on #197 to fix #196.

Closes #197