### PR TITLE
Add support for parsing/stringifying fragment identifier

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -371,7 +371,9 @@ queryString.stringifyUrl({url: 'https://foo.bar?foo=baz', query: {foo: 'bar'}});
 
 queryString.stringifyUrl({
 	url: 'https://foo.bar',
-	query: {top: 'foo'},
+	query: {
+		top: 'foo'
+	},
 	fragmentIdentifier: 'bar'
 });
 //=> 'https://foo.bar?top=foo#bar'

--- a/index.d.ts
+++ b/index.d.ts
@@ -356,7 +356,7 @@ Stringify an object into a URL with a query string and sorting the keys. The inv
 
 Query items in the `query` property overrides queries in the `url` property.
 
-Fragment identifier in the `fragmentIdentifier` property overrides fragment identifier in the `url` property
+The `fragmentIdentifier` property overrides the fragment identifier in the `url` property.
 
 @example
 ```

--- a/index.d.ts
+++ b/index.d.ts
@@ -121,6 +121,21 @@ export interface ParseOptions {
 	```
 	*/
 	readonly parseBooleans?: boolean;
+	
+	/**
+	Parse the fragment identifier from the URL.
+
+	@default false
+
+	@example
+	```
+	import queryString = require('query-string');
+
+	queryString.parseUrl('https://foo.bar?foo=bar#xyz');
+	//=> {url: 'https://foo.bar', query: {foo: 'bar'}, fragment: 'xyz'}
+	```
+	*/
+	readonly parseFragment?: boolean;
 }
 
 export interface ParsedQuery<T = string> {
@@ -142,6 +157,7 @@ export function parse(query: string, options?: ParseOptions): ParsedQuery;
 export interface ParsedUrl {
 	readonly url: string;
 	readonly query: ParsedQuery;
+	readonly fragment?: string;
 }
 
 /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -131,11 +131,11 @@ export interface ParseOptions {
 	```
 	import queryString = require('query-string');
 
-	queryString.parseUrl('https://foo.bar?foo=bar#xyz');
-	//=> {url: 'https://foo.bar', query: {foo: 'bar'}, fragment: 'xyz'}
+	queryString.parseUrl('https://foo.bar?foo=bar#xyz', {parseFragmentIdentifier: true});
+	//=> {url: 'https://foo.bar', query: {foo: 'bar'}, fragmentIdentifier: 'xyz'}
 	```
 	*/
-	readonly parseFragment?: boolean;
+	readonly parseFragmentIdentifier?: boolean;
 }
 
 export interface ParsedQuery<T = string> {
@@ -157,7 +157,7 @@ export function parse(query: string, options?: ParseOptions): ParsedQuery;
 export interface ParsedUrl {
 	readonly url: string;
 	readonly query: ParsedQuery;
-	readonly fragment?: string;
+	readonly fragmentIdentifier?: string;
 }
 
 /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -166,6 +166,7 @@ export interface ParsedUrl {
 
 /**
 Extract the URL and the query string as an object.
+Optionally object contains `fragmentIdentifier` if `parseFragmentIdentifier` is `true` in options.
 
 @param url - The URL to parse.
 
@@ -175,6 +176,9 @@ import queryString = require('query-string');
 
 queryString.parseUrl('https://foo.bar?foo=bar');
 //=> {url: 'https://foo.bar', query: {foo: 'bar'}}
+
+queryString.parseUrl('https://foo.bar?foo=bar#xyz', {parseFragmentIdentifier: true});
+//=> {url: 'https://foo.bar', query: {foo: 'bar'}, fragmentIdentifier: 'xyz'}
 ```
 */
 export function parseUrl(url: string, options?: ParseOptions): ParsedUrl;
@@ -351,6 +355,8 @@ export function extract(url: string): string;
 Stringify an object into a URL with a query string and sorting the keys. The inverse of [`.parseUrl()`](https://github.com/sindresorhus/query-string#parseurlstring-options)
 
 Query items in the `query` property overrides queries in the `url` property.
+
+Fragment identifier in the `fragmentIdentifier` property overrides fragment identifier in the `url` property
 
 @example
 ```

--- a/index.d.ts
+++ b/index.d.ts
@@ -159,7 +159,8 @@ export interface ParsedUrl {
 	readonly query: ParsedQuery;
 
 	/**
-	If the `parseFragmentIdentifier` is `true`, the object will also contain a `fragmentIdentifier` property.
+	The fragment identifier of the URL.
+	Present when `parseFragmentIdentifier` is `true`.
 	*/
 	readonly fragmentIdentifier?: string;
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -166,7 +166,7 @@ export interface ParsedUrl {
 
 /**
 Extract the URL and the query string as an object.
-Optionally object contains `fragmentIdentifier` if `parseFragmentIdentifier` is `true` in options.
+If the `parseFragmentIdentifier` is `true`, the object will also contain a `fragmentIdentifier` property.
 
 @param url - The URL to parse.
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -159,7 +159,7 @@ export interface ParsedUrl {
 	readonly query: ParsedQuery;
 
 	/**
-	The fragment identifier of the URL.
+	If the `parseFragmentIdentifier` is `true`, the object will also contain a `fragmentIdentifier` property.
 	*/
 	readonly fragmentIdentifier?: string;
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -157,6 +157,9 @@ export function parse(query: string, options?: ParseOptions): ParsedQuery;
 export interface ParsedUrl {
 	readonly url: string;
 	readonly query: ParsedQuery;
+	/**
+	The fragment identifier of the URL.
+	*/
 	readonly fragmentIdentifier?: string;
 }
 
@@ -326,6 +329,27 @@ export interface StringifyOptions {
 	```
 	*/
 	readonly skipEmptyString?: boolean;
+
+	/**
+	Adds the fragment identifier to the URL.
+
+	@default false
+
+	@example
+	```
+	import queryString = require('query-string');
+
+	queryString.stringifyUrl({
+		url: 'https://foo.bar',
+		query: {top: 'foo'},
+		fragmentIdentifier: 'bar'
+	}, {
+		parseFragmentIdentifier: true
+	});
+	//=> 'https://foo.bar?top=foo#bar'
+	```
+	*/
+	readonly parseFragmentIdentifier?: boolean;
 }
 
 /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -168,7 +168,8 @@ export interface ParsedUrl {
 
 /**
 Extract the URL and the query string as an object.
-If the `parseFragmentIdentifier` is `true`, the object will also contain a `fragmentIdentifier` property.
+
+If the `parseFragmentIdentifier` option is `true`, the object will also contain a `fragmentIdentifier` property.
 
 @param url - The URL to parse.
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -157,6 +157,7 @@ export function parse(query: string, options?: ParseOptions): ParsedQuery;
 export interface ParsedUrl {
 	readonly url: string;
 	readonly query: ParsedQuery;
+
 	/**
 	The fragment identifier of the URL.
 	*/

--- a/index.d.ts
+++ b/index.d.ts
@@ -123,7 +123,7 @@ export interface ParseOptions {
 	readonly parseBooleans?: boolean;
 	
 	/**
-	Parse the fragment identifier from the URL.
+	Parse the fragment identifier from the URL and add it to result object.
 
 	@default false
 
@@ -330,27 +330,6 @@ export interface StringifyOptions {
 	```
 	*/
 	readonly skipEmptyString?: boolean;
-
-	/**
-	Adds the fragment identifier to the URL.
-
-	@default false
-
-	@example
-	```
-	import queryString = require('query-string');
-
-	queryString.stringifyUrl({
-		url: 'https://foo.bar',
-		query: {top: 'foo'},
-		fragmentIdentifier: 'bar'
-	}, {
-		parseFragmentIdentifier: true
-	});
-	//=> 'https://foo.bar?top=foo#bar'
-	```
-	*/
-	readonly parseFragmentIdentifier?: boolean;
 }
 
 /**
@@ -380,6 +359,13 @@ queryString.stringifyUrl({url: 'https://foo.bar', query: {foo: 'bar'}});
 
 queryString.stringifyUrl({url: 'https://foo.bar?foo=baz', query: {foo: 'bar'}});
 //=> 'https://foo.bar?foo=bar'
+
+queryString.stringifyUrl({
+	url: 'https://foo.bar',
+	query: {top: 'foo'},
+	fragmentIdentifier: 'bar'
+});
+//=> 'https://foo.bar?top=foo#bar'
 ```
 */
 export function stringifyUrl(

--- a/index.d.ts
+++ b/index.d.ts
@@ -160,7 +160,8 @@ export interface ParsedUrl {
 
 	/**
 	The fragment identifier of the URL.
-	Present when `parseFragmentIdentifier` is `true`.
+
+	Present when the `parseFragmentIdentifier` option is `true`.
 	*/
 	readonly fragmentIdentifier?: string;
 }

--- a/index.js
+++ b/index.js
@@ -338,17 +338,24 @@ exports.stringify = (object, options) => {
 };
 
 exports.parseUrl = (input, options) => {
+	options = Object.assign({
+		decode: true
+	}, options);
 	const [url, hash] = splitOnFirst(input, '#');
 	return Object.assign(
 		{
 			url: url.split('?')[0] || '',
 			query: parse(extract(input), options)
 		},
-		options && options.parseFragmentIdentifier && hash ? {fragmentIdentifier: hash} : {}
+		options && options.parseFragmentIdentifier && hash ? {fragmentIdentifier: decode(hash, options)} : {}
 	);
 };
 
 exports.stringifyUrl = (input, options) => {
+	options = Object.assign({
+		encode: true,
+		strict: true
+	}, options);
 	const url = removeHash(input.url).split('?')[0] || '';
 	const queryFromUrl = exports.extract(input.url);
 	const parsedQueryFromUrl = exports.parse(queryFromUrl);
@@ -359,8 +366,8 @@ exports.stringifyUrl = (input, options) => {
 		queryString = `?${queryString}`;
 	}
 
-	if (options && options.parseFragmentIdentifier && input.fragmentIdentifier) {
-		hash = `#${input.fragmentIdentifier}`;
+	if (input.fragmentIdentifier) {
+		hash = `#${encode(input.fragmentIdentifier, options)}`;
 	}
 
 	return `${url}${queryString}${hash}`;

--- a/index.js
+++ b/index.js
@@ -338,10 +338,14 @@ exports.stringify = (object, options) => {
 };
 
 exports.parseUrl = (input, options) => {
-	return {
-		url: removeHash(input).split('?')[0] || '',
-		query: parse(extract(input), options)
-	};
+	const [url, hash] = splitOnFirst(input, '#');
+	return Object.assign(
+		{
+			url: url.split('?')[0] || '',
+			query: parse(extract(input), options)
+		},
+		options && options.parseFragment && hash ? {fragment: hash} : {}
+	);
 };
 
 exports.stringifyUrl = (input, options) => {

--- a/index.js
+++ b/index.js
@@ -344,7 +344,7 @@ exports.parseUrl = (input, options) => {
 			url: url.split('?')[0] || '',
 			query: parse(extract(input), options)
 		},
-		options && options.parseFragment && hash ? {fragment: hash} : {}
+		options && options.parseFragmentIdentifier && hash ? {fragmentIdentifier: hash} : {}
 	);
 };
 

--- a/index.js
+++ b/index.js
@@ -352,11 +352,15 @@ exports.stringifyUrl = (input, options) => {
 	const url = removeHash(input.url).split('?')[0] || '';
 	const queryFromUrl = exports.extract(input.url);
 	const parsedQueryFromUrl = exports.parse(queryFromUrl);
-	const hash = getHash(input.url);
+	let hash = getHash(input.url);
 	const query = Object.assign(parsedQueryFromUrl, input.query);
 	let queryString = exports.stringify(query, options);
 	if (queryString) {
 		queryString = `?${queryString}`;
+	}
+
+	if (options && options.parseFragmentIdentifier && input.fragmentIdentifier) {
+		hash = `#${input.fragmentIdentifier}`;
 	}
 
 	return `${url}${queryString}${hash}`;

--- a/index.js
+++ b/index.js
@@ -362,13 +362,14 @@ exports.stringifyUrl = (input, options) => {
 	const url = removeHash(input.url).split('?')[0] || '';
 	const queryFromUrl = exports.extract(input.url);
 	const parsedQueryFromUrl = exports.parse(queryFromUrl);
-	let hash = getHash(input.url);
+
 	const query = Object.assign(parsedQueryFromUrl, input.query);
 	let queryString = exports.stringify(query, options);
 	if (queryString) {
 		queryString = `?${queryString}`;
 	}
 
+	let hash = getHash(input.url);
 	if (input.fragmentIdentifier) {
 		hash = `#${encode(input.fragmentIdentifier, options)}`;
 	}

--- a/index.js
+++ b/index.js
@@ -341,7 +341,9 @@ exports.parseUrl = (input, options) => {
 	options = Object.assign({
 		decode: true
 	}, options);
+
 	const [url, hash] = splitOnFirst(input, '#');
+
 	return Object.assign(
 		{
 			url: url.split('?')[0] || '',
@@ -356,6 +358,7 @@ exports.stringifyUrl = (input, options) => {
 		encode: true,
 		strict: true
 	}, options);
+
 	const url = removeHash(input.url).split('?')[0] || '';
 	const queryFromUrl = exports.extract(input.url);
 	const parsedQueryFromUrl = exports.parse(queryFromUrl);

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -88,7 +88,7 @@ expectType<queryString.ParsedUrl>(
 	queryString.parseUrl('?foo=true', {parseBooleans: true})
 );
 expectType<queryString.ParsedUrl>(
-	queryString.parseUrl('?foo=true#bar', {parseFragment: true})
+	queryString.parseUrl('?foo=true#bar', {parseFragmentIdentifier: true})
 );
 
 // Extract

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -87,6 +87,9 @@ expectType<queryString.ParsedUrl>(
 expectType<queryString.ParsedUrl>(
 	queryString.parseUrl('?foo=true', {parseBooleans: true})
 );
+expectType<queryString.ParsedUrl>(
+	queryString.parseUrl('?foo=true#bar', {parseFragment: true})
+);
 
 // Extract
 expectType<string>(queryString.extract('http://foo.bar/?abc=def&hij=klm'));

--- a/readme.md
+++ b/readme.md
@@ -339,8 +339,6 @@ Note: This behaviour can be changed with the `skipNull` option.
 
 Extract the URL and the query string as an object.
 
-The `options` are the same as for `.parse()`.
-
 Returns an object with a `url` and `query` property.
 
 ```js
@@ -349,6 +347,14 @@ const queryString = require('query-string');
 queryString.parseUrl('https://foo.bar?foo=bar');
 //=> {url: 'https://foo.bar', query: {foo: 'bar'}}
 ```
+
+#### options
+
+Type: `object`
+
+The `options` are the same as for `.parse()`.
+
+Extra options are as below
 
 ##### parseFragmentIdentifier
 
@@ -382,7 +388,7 @@ queryString.stringifyUrl({url: 'https://foo.bar?foo=baz', query: {foo: 'bar'}});
 //=> 'https://foo.bar?foo=bar'
 ```
 
-#### object
+#### options
 
 Type: `object`
 
@@ -397,6 +403,24 @@ The URL to stringify.
 Type: `object`
 
 Query items to add to the URL.
+
+##### parseFragmentIdentifier
+
+Adds the fragment identifier to the URL.
+
+Type: `boolean`\
+Default: `false`
+
+```js
+queryString.stringifyUrl({
+	url: 'https://foo.bar',
+	query: {top: 'foo'},
+	fragmentIdentifier: 'bar'
+}, {
+	parseFragmentIdentifier: true
+});
+//=> 'https://foo.bar?top=foo#bar'
+```
 
 ## Nesting
 

--- a/readme.md
+++ b/readme.md
@@ -385,13 +385,13 @@ Type: `object`
 Query items to add to the URL.
 #### parseFragmentIdentifier
 
-Extracts the fragment identifier from url
+Parse the fragment identifier from the URL.
 
 Type: `boolean`\
 Default: `false`
 
 ```js
-import queryString = require('query-string');
+const queryString = require('query-string');
 
 queryString.parseUrl('https://foo.bar?foo=bar#xyz', {parseFragmentIdentifier: true});
 //=> {url: 'https://foo.bar', query: {foo: 'bar'}, fragmentIdentifier: 'xyz'}

--- a/readme.md
+++ b/readme.md
@@ -383,6 +383,19 @@ The URL to stringify.
 Type: `object`
 
 Query items to add to the URL.
+#### parseFragmentIdentifier
+
+Extracts the fragment identifier from url
+
+Type: `boolean`\
+Default: `false`
+
+```js
+import queryString = require('query-string');
+
+queryString.parseUrl('https://foo.bar?foo=bar#xyz', {parseFragmentIdentifier: true});
+//=> {url: 'https://foo.bar', query: {foo: 'bar'}, fragmentIdentifier: 'xyz'}
+```
 
 ## Nesting
 

--- a/readme.md
+++ b/readme.md
@@ -340,7 +340,7 @@ Note: This behaviour can be changed with the `skipNull` option.
 Extract the URL and the query string as an object.
 
 Returns an object with a `url` and `query` property.
-Optionally object contains `fragmentIdentifier` if `parseFragmentIdentifier` is `true` in options.
+If the `parseFragmentIdentifier` is `true`, the object will also contain a `fragmentIdentifier` property.
 
 ```js
 const queryString = require('query-string');
@@ -384,7 +384,7 @@ Returns a string with the URL and a query string.
 
 Query items in the `query` property overrides queries in the `url` property.
 
-Fragment identifier in the `fragmentIdentifier` property overrides fragment identifier in the `url` property
+The `fragmentIdentifier` property overrides the fragment identifier in the `url` property.
 
 ```js
 queryString.stringifyUrl({url: 'https://foo.bar', query: {foo: 'bar'}});

--- a/readme.md
+++ b/readme.md
@@ -383,7 +383,8 @@ The URL to stringify.
 Type: `object`
 
 Query items to add to the URL.
-#### parseFragmentIdentifier
+
+##### parseFragmentIdentifier
 
 Parse the fragment identifier from the URL.
 

--- a/readme.md
+++ b/readme.md
@@ -357,7 +357,7 @@ queryString.parseUrl('https://foo.bar?foo=bar#xyz', {parseFragmentIdentifier: tr
 
 Type: `object`
 
-The `options` are the same as for `.parse()`.
+The options are the same as for `.parse()`.
 
 Extra options are as below.
 
@@ -396,7 +396,9 @@ queryString.stringifyUrl({url: 'https://foo.bar?foo=baz', query: {foo: 'bar'}});
 
 queryString.stringifyUrl({
 	url: 'https://foo.bar',
-	query: {top: 'foo'},
+	query: {
+		top: 'foo'
+	},
 	fragmentIdentifier: 'bar'
 });
 //=> 'https://foo.bar?top=foo#bar'

--- a/readme.md
+++ b/readme.md
@@ -354,7 +354,7 @@ Type: `object`
 
 The `options` are the same as for `.parse()`.
 
-Extra options are as below
+Extra options are as below.
 
 ##### parseFragmentIdentifier
 
@@ -386,6 +386,13 @@ queryString.stringifyUrl({url: 'https://foo.bar', query: {foo: 'bar'}});
 
 queryString.stringifyUrl({url: 'https://foo.bar?foo=baz', query: {foo: 'bar'}});
 //=> 'https://foo.bar?foo=bar'
+
+queryString.stringifyUrl({
+	url: 'https://foo.bar',
+	query: {top: 'foo'},
+	fragmentIdentifier: 'bar'
+});
+//=> 'https://foo.bar?top=foo#bar'
 ```
 
 #### options
@@ -403,24 +410,6 @@ The URL to stringify.
 Type: `object`
 
 Query items to add to the URL.
-
-##### parseFragmentIdentifier
-
-Adds the fragment identifier to the URL.
-
-Type: `boolean`\
-Default: `false`
-
-```js
-queryString.stringifyUrl({
-	url: 'https://foo.bar',
-	query: {top: 'foo'},
-	fragmentIdentifier: 'bar'
-}, {
-	parseFragmentIdentifier: true
-});
-//=> 'https://foo.bar?top=foo#bar'
-```
 
 ## Nesting
 

--- a/readme.md
+++ b/readme.md
@@ -340,7 +340,8 @@ Note: This behaviour can be changed with the `skipNull` option.
 Extract the URL and the query string as an object.
 
 Returns an object with a `url` and `query` property.
-If the `parseFragmentIdentifier` is `true`, the object will also contain a `fragmentIdentifier` property.
+
+If the `parseFragmentIdentifier` option is `true`, the object will also contain a `fragmentIdentifier` property.
 
 ```js
 const queryString = require('query-string');

--- a/readme.md
+++ b/readme.md
@@ -340,12 +340,16 @@ Note: This behaviour can be changed with the `skipNull` option.
 Extract the URL and the query string as an object.
 
 Returns an object with a `url` and `query` property.
+Optionally object contains `fragmentIdentifier` if `parseFragmentIdentifier` is `true` in options.
 
 ```js
 const queryString = require('query-string');
 
 queryString.parseUrl('https://foo.bar?foo=bar');
 //=> {url: 'https://foo.bar', query: {foo: 'bar'}}
+
+queryString.parseUrl('https://foo.bar?foo=bar#xyz', {parseFragmentIdentifier: true});
+//=> {url: 'https://foo.bar', query: {foo: 'bar'}, fragmentIdentifier: 'xyz'}
 ```
 
 #### options
@@ -379,6 +383,8 @@ The `options` are the same as for `.stringify()`.
 Returns a string with the URL and a query string.
 
 Query items in the `query` property overrides queries in the `url` property.
+
+Fragment identifier in the `fragmentIdentifier` property overrides fragment identifier in the `url` property
 
 ```js
 queryString.stringifyUrl({url: 'https://foo.bar', query: {foo: 'bar'}});

--- a/readme.md
+++ b/readme.md
@@ -350,6 +350,20 @@ queryString.parseUrl('https://foo.bar?foo=bar');
 //=> {url: 'https://foo.bar', query: {foo: 'bar'}}
 ```
 
+##### parseFragmentIdentifier
+
+Parse the fragment identifier from the URL.
+
+Type: `boolean`\
+Default: `false`
+
+```js
+const queryString = require('query-string');
+
+queryString.parseUrl('https://foo.bar?foo=bar#xyz', {parseFragmentIdentifier: true});
+//=> {url: 'https://foo.bar', query: {foo: 'bar'}, fragmentIdentifier: 'xyz'}
+```
+
 ### .stringifyUrl(object, options?)
 
 Stringify an object into a URL with a query string and sorting the keys. The inverse of [`.parseUrl()`](https://github.com/sindresorhus/query-string#parseurlstring-options)
@@ -383,20 +397,6 @@ The URL to stringify.
 Type: `object`
 
 Query items to add to the URL.
-
-##### parseFragmentIdentifier
-
-Parse the fragment identifier from the URL.
-
-Type: `boolean`\
-Default: `false`
-
-```js
-const queryString = require('query-string');
-
-queryString.parseUrl('https://foo.bar?foo=bar#xyz', {parseFragmentIdentifier: true});
-//=> {url: 'https://foo.bar', query: {foo: 'bar'}, fragmentIdentifier: 'xyz'}
-```
 
 ## Nesting
 

--- a/readme.md
+++ b/readme.md
@@ -402,7 +402,7 @@ queryString.stringifyUrl({
 //=> 'https://foo.bar?top=foo#bar'
 ```
 
-#### options
+#### object
 
 Type: `object`
 

--- a/test/parse-url.js
+++ b/test/parse-url.js
@@ -18,6 +18,12 @@ test('handles strings with query string that contain =', t => {
 	t.deepEqual(queryString.parseUrl('https://foo.bar?foo=bar=&foo=baz='), {url: 'https://foo.bar', query: {foo: ['bar=', 'baz=']}});
 });
 
+test('handles strings with fragment identifier', t => {
+	t.deepEqual(queryString.parseUrl('https://foo.bar?top=foo#bar', {parseFragment: true}), {url: 'https://foo.bar', query: {top: 'foo'}, fragment: 'bar'});
+	t.deepEqual(queryString.parseUrl('https://foo.bar?foo=bar&foo=baz#top', {parseFragment: true}), {url: 'https://foo.bar', query: {foo: ['bar', 'baz']}, fragment: 'top'});
+	t.deepEqual(queryString.parseUrl('https://foo.bar/#top', {parseFragment: true}), {url: 'https://foo.bar/', query: {}, fragment: 'top'});
+});
+
 test('throws for invalid values', t => {
 	t.throws(() => {
 		queryString.parseUrl(null);

--- a/test/parse-url.js
+++ b/test/parse-url.js
@@ -22,6 +22,7 @@ test('handles strings with fragment identifier', t => {
 	t.deepEqual(queryString.parseUrl('https://foo.bar?top=foo#bar', {parseFragmentIdentifier: true}), {url: 'https://foo.bar', query: {top: 'foo'}, fragmentIdentifier: 'bar'});
 	t.deepEqual(queryString.parseUrl('https://foo.bar?foo=bar&foo=baz#top', {parseFragmentIdentifier: true}), {url: 'https://foo.bar', query: {foo: ['bar', 'baz']}, fragmentIdentifier: 'top'});
 	t.deepEqual(queryString.parseUrl('https://foo.bar/#top', {parseFragmentIdentifier: true}), {url: 'https://foo.bar/', query: {}, fragmentIdentifier: 'top'});
+	t.deepEqual(queryString.parseUrl('https://foo.bar/#st%C3%A5le', {parseFragmentIdentifier: true}), {url: 'https://foo.bar/', query: {}, fragmentIdentifier: 'ståle'});
 });
 
 test('throws for invalid values', t => {

--- a/test/parse-url.js
+++ b/test/parse-url.js
@@ -19,9 +19,9 @@ test('handles strings with query string that contain =', t => {
 });
 
 test('handles strings with fragment identifier', t => {
-	t.deepEqual(queryString.parseUrl('https://foo.bar?top=foo#bar', {parseFragment: true}), {url: 'https://foo.bar', query: {top: 'foo'}, fragment: 'bar'});
-	t.deepEqual(queryString.parseUrl('https://foo.bar?foo=bar&foo=baz#top', {parseFragment: true}), {url: 'https://foo.bar', query: {foo: ['bar', 'baz']}, fragment: 'top'});
-	t.deepEqual(queryString.parseUrl('https://foo.bar/#top', {parseFragment: true}), {url: 'https://foo.bar/', query: {}, fragment: 'top'});
+	t.deepEqual(queryString.parseUrl('https://foo.bar?top=foo#bar', {parseFragmentIdentifier: true}), {url: 'https://foo.bar', query: {top: 'foo'}, fragmentIdentifier: 'bar'});
+	t.deepEqual(queryString.parseUrl('https://foo.bar?foo=bar&foo=baz#top', {parseFragmentIdentifier: true}), {url: 'https://foo.bar', query: {foo: ['bar', 'baz']}, fragmentIdentifier: 'top'});
+	t.deepEqual(queryString.parseUrl('https://foo.bar/#top', {parseFragmentIdentifier: true}), {url: 'https://foo.bar/', query: {}, fragmentIdentifier: 'top'});
 });
 
 test('throws for invalid values', t => {

--- a/test/stringify-url.js
+++ b/test/stringify-url.js
@@ -20,12 +20,12 @@ test('stringify URL with a query string', t => {
 });
 
 test('stringify URL with fragment identifier', t => {
-	const config = {parseFragmentIdentifier: true};
-	t.deepEqual(queryString.stringifyUrl({url: 'https://foo.bar', query: {top: 'foo'}, fragmentIdentifier: 'bar'}, config), 'https://foo.bar?top=foo#bar');
-	t.deepEqual(queryString.stringifyUrl({url: 'https://foo.bar', query: {foo: ['bar', 'baz']}, fragmentIdentifier: 'top'}, config), 'https://foo.bar?foo=bar&foo=baz#top');
-	t.deepEqual(queryString.stringifyUrl({url: 'https://foo.bar/', query: {}, fragmentIdentifier: 'top'}, config), 'https://foo.bar/#top');
-	t.deepEqual(queryString.stringifyUrl({url: 'https://foo.bar/#abc', query: {}, fragmentIdentifier: 'top'}, config), 'https://foo.bar/#top');
-	t.deepEqual(queryString.stringifyUrl({url: 'https://foo.bar', query: {}}, config), 'https://foo.bar');
+	t.deepEqual(queryString.stringifyUrl({url: 'https://foo.bar', query: {top: 'foo'}, fragmentIdentifier: 'bar'}), 'https://foo.bar?top=foo#bar');
+	t.deepEqual(queryString.stringifyUrl({url: 'https://foo.bar', query: {foo: ['bar', 'baz']}, fragmentIdentifier: 'top'}), 'https://foo.bar?foo=bar&foo=baz#top');
+	t.deepEqual(queryString.stringifyUrl({url: 'https://foo.bar/', query: {}, fragmentIdentifier: 'top'}), 'https://foo.bar/#top');
+	t.deepEqual(queryString.stringifyUrl({url: 'https://foo.bar/#abc', query: {}, fragmentIdentifier: 'top'}), 'https://foo.bar/#top');
+	t.deepEqual(queryString.stringifyUrl({url: 'https://foo.bar', query: {}}), 'https://foo.bar');
+	t.deepEqual(queryString.stringifyUrl({url: 'https://foo.bar', query: {}, fragmentIdentifier: 'foo bar'}), 'https://foo.bar#foo%20bar');
 });
 
 test('skipEmptyString:: stringify URL with a query string', t => {

--- a/test/stringify-url.js
+++ b/test/stringify-url.js
@@ -25,6 +25,7 @@ test('stringify URL with fragment identifier', t => {
 	t.deepEqual(queryString.stringifyUrl({url: 'https://foo.bar', query: {foo: ['bar', 'baz']}, fragmentIdentifier: 'top'}, config), 'https://foo.bar?foo=bar&foo=baz#top');
 	t.deepEqual(queryString.stringifyUrl({url: 'https://foo.bar/', query: {}, fragmentIdentifier: 'top'}, config), 'https://foo.bar/#top');
 	t.deepEqual(queryString.stringifyUrl({url: 'https://foo.bar/#abc', query: {}, fragmentIdentifier: 'top'}, config), 'https://foo.bar/#top');
+	t.deepEqual(queryString.stringifyUrl({url: 'https://foo.bar', query: {}}, config), 'https://foo.bar');
 });
 
 test('skipEmptyString:: stringify URL with a query string', t => {

--- a/test/stringify-url.js
+++ b/test/stringify-url.js
@@ -19,6 +19,14 @@ test('stringify URL with a query string', t => {
 	t.deepEqual(queryString.stringifyUrl({url: 'https://foo.bar?foo=baz', query: {foo: 'bar'}}), 'https://foo.bar?foo=bar');
 });
 
+test('stringify URL with fragment identifier', t => {
+	const config = {parseFragmentIdentifier: true};
+	t.deepEqual(queryString.stringifyUrl({url: 'https://foo.bar', query: {top: 'foo'}, fragmentIdentifier: 'bar'}, config), 'https://foo.bar?top=foo#bar');
+	t.deepEqual(queryString.stringifyUrl({url: 'https://foo.bar', query: {foo: ['bar', 'baz']}, fragmentIdentifier: 'top'}, config), 'https://foo.bar?foo=bar&foo=baz#top');
+	t.deepEqual(queryString.stringifyUrl({url: 'https://foo.bar/', query: {}, fragmentIdentifier: 'top'}, config), 'https://foo.bar/#top');
+	t.deepEqual(queryString.stringifyUrl({url: 'https://foo.bar/#abc', query: {}, fragmentIdentifier: 'top'}, config), 'https://foo.bar/#top');
+});
+
 test('skipEmptyString:: stringify URL with a query string', t => {
 	const config = {skipEmptyString: true};
 


### PR DESCRIPTION
Fixes #220 

Add a new option `parseFragment`, which will provide the hash in the `parseURL` result. The new option is to prevent it from becoming a breaking change

Seems `Fragment Identifier` is the technical jargon for it, let me know if it's ok or hash seems like a better choice

cc\ @sindresorhus 