### PR TITLE
Add a condition to check and make sure the query string parsed to a n…

### DIFF
--- a/index.js
+++ b/index.js
@@ -190,10 +190,15 @@ function extract(input) {
 }
 
 function parseValue(value, options) {
+	const initialValue = value;
 	if (options.parseNumbers && !Number.isNaN(Number(value)) && (typeof value === 'string' && value.trim() !== '')) {
 		value = Number(value);
 	} else if (options.parseBooleans && value !== null && (value.toLowerCase() === 'true' || value.toLowerCase() === 'false')) {
 		value = value.toLowerCase() === 'true';
+	}
+
+	if (initialValue.toString() !== value.toString()) {
+		return initialValue;
 	}
 
 	return value;


### PR DESCRIPTION
…umber is not solved as an equation when it contains a + or an e or any other math characters

When the values in the query string are converted to numbers, if they contain values such as +,-,*,e they will be treated as an equation and solved. for example if the value being parsed is 192e11 is converted to 192000000 and 1920000000000000000000000 gets converted to 1.92e+24 etc..