### PR TITLE
Fix value being decoded twice with `arrayFormat` option set to `separator`

### DIFF
--- a/index.js
+++ b/index.js
@@ -231,7 +231,7 @@ function parse(input, options) {
 
 		// Missing `=` should be `null`:
 		// http://w3.org/TR/2012/WD-url-20120524/#collect-url-parameters
-		value = value === undefined ? null : options.arrayFormat === 'comma' ? value : decode(value, options);
+		value = value === undefined ? null : ['comma', 'separator'].indexOf(options.arrayFormat) > -1 ? value : decode(value, options);
 		formatter(decode(key, options), value, ret);
 	}
 

--- a/index.js
+++ b/index.js
@@ -231,7 +231,7 @@ function parse(input, options) {
 
 		// Missing `=` should be `null`:
 		// http://w3.org/TR/2012/WD-url-20120524/#collect-url-parameters
-		value = value === undefined ? null : ['comma', 'separator'].indexOf(options.arrayFormat) > -1 ? value : decode(value, options);
+		value = value === undefined ? null : ['comma', 'separator'].includes(options.arrayFormat) ? value : decode(value, options);
 		formatter(decode(key, options), value, ret);
 	}
 

--- a/test/parse.js
+++ b/test/parse.js
@@ -311,13 +311,15 @@ test('query strings having comma encoded and format option as `comma`', t => {
 	});
 });
 
-test('value shoud not be decoded twice with arrayFormat set as `separator`', t => {
+test('value should not be decoded twice with arrayFormat set as `separator`', t => {
 	t.deepEqual(queryString.parse('foo=2020-01-01T00:00:00%2B03:00', {arrayFormat: 'separator'}), {
 		foo: '2020-01-01T00:00:00+03:00'
 	});
 });
 
 // See https://github.com/sindresorhus/query-string/pull/243#issuecomment-591179715
-test.failing('value separated by encoded comma will not be parsed as array with arrayFormat set as `comma`', t => {
-	t.fail();
+test.failing('value separated by encoded comma will not be parsed as array with arrayFormat option set to `comma`', t => {
+	t.deepEqual(queryString.parse('id=1%2C2%2C3', {arrayFormat: 'comma', parseNumbers: true}), {
+		id: [1, 2, 3]
+	});
 });

--- a/test/parse.js
+++ b/test/parse.js
@@ -310,3 +310,9 @@ test('query strings having comma encoded and format option as `comma`', t => {
 		]
 	});
 });
+
+test('value shoud not be decoded twice with arrayFormat set as `separator`', t => {
+	t.deepEqual(queryString.parse('foo=2020-01-01T00:00:00%2B03:00', {arrayFormat: 'separator'}), {
+		foo: '2020-01-01T00:00:00+03:00'
+	});
+});

--- a/test/parse.js
+++ b/test/parse.js
@@ -311,14 +311,14 @@ test('query strings having comma encoded and format option as `comma`', t => {
 	});
 });
 
-test('value should not be decoded twice with arrayFormat set as `separator`', t => {
+test('value should not be decoded twice with `arrayFormat` option set as `separator`', t => {
 	t.deepEqual(queryString.parse('foo=2020-01-01T00:00:00%2B03:00', {arrayFormat: 'separator'}), {
 		foo: '2020-01-01T00:00:00+03:00'
 	});
 });
 
-// See https://github.com/sindresorhus/query-string/pull/243#issuecomment-591179715
-test.failing('value separated by encoded comma will not be parsed as array with arrayFormat option set to `comma`', t => {
+// See https://github.com/sindresorhus/query-string/issues/242
+test.failing('value separated by encoded comma will not be parsed as array with `arrayFormat` option set to `comma`', t => {
 	t.deepEqual(queryString.parse('id=1%2C2%2C3', {arrayFormat: 'comma', parseNumbers: true}), {
 		id: [1, 2, 3]
 	});


### PR DESCRIPTION
fix part of  #242  ( caused by #236 