### PR TITLE
Fix `arrayFormatSeparator` TypeScript type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -61,7 +61,7 @@ export interface ParseOptions {
 
 	@default ,
 	*/
-	readonly arrayFormatSeparator?: 'string';
+	readonly arrayFormatSeparator?: string;
 
 	/**
 	Supports both `Function` as a custom sorting function or `false` to disable sorting.
@@ -229,7 +229,7 @@ export interface StringifyOptions {
 
 	@default ,
 	*/
-	readonly arrayFormatSeparator?: 'string';
+	readonly arrayFormatSeparator?: string;
 
 	/**
 	Supports both `Function` as a custom sorting function or `false` to disable sorting.


### PR DESCRIPTION
Remove quotes from `'string'` type