### PR TITLE
arrayFormatSeparator changed to correct type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -229,7 +229,7 @@ export interface StringifyOptions {
 
 	@default ,
 	*/
-	readonly arrayFormatSeparator?: 'string';
+	readonly arrayFormatSeparator?: string;
 
 	/**
 	Supports both `Function` as a custom sorting function or `false` to disable sorting.


### PR DESCRIPTION
fixes recently submitted issue: https://github.com/sindresorhus/query-string/issues/247