### PR TITLE
Fix sorting existing query params in URL when `sort` option is false

### DIFF
--- a/index.js
+++ b/index.js
@@ -361,7 +361,7 @@ exports.stringifyUrl = (input, options) => {
 
 	const url = removeHash(input.url).split('?')[0] || '';
 	const queryFromUrl = exports.extract(input.url);
-	const parsedQueryFromUrl = exports.parse(queryFromUrl, { sort: false });
+	const parsedQueryFromUrl = exports.parse(queryFromUrl, {sort: false});
 
 	const query = Object.assign(parsedQueryFromUrl, input.query);
 	let queryString = exports.stringify(query, options);

--- a/index.js
+++ b/index.js
@@ -361,7 +361,7 @@ exports.stringifyUrl = (input, options) => {
 
 	const url = removeHash(input.url).split('?')[0] || '';
 	const queryFromUrl = exports.extract(input.url);
-	const parsedQueryFromUrl = exports.parse(queryFromUrl, options);
+	const parsedQueryFromUrl = exports.parse(queryFromUrl, { sort: false });
 
 	const query = Object.assign(parsedQueryFromUrl, input.query);
 	let queryString = exports.stringify(query, options);

--- a/index.js
+++ b/index.js
@@ -361,7 +361,7 @@ exports.stringifyUrl = (input, options) => {
 
 	const url = removeHash(input.url).split('?')[0] || '';
 	const queryFromUrl = exports.extract(input.url);
-	const parsedQueryFromUrl = exports.parse(queryFromUrl);
+	const parsedQueryFromUrl = exports.parse(queryFromUrl, options);
 
 	const query = Object.assign(parsedQueryFromUrl, input.query);
 	let queryString = exports.stringify(query, options);

--- a/test/stringify-url.js
+++ b/test/stringify-url.js
@@ -52,3 +52,8 @@ test('stringify URL from the result of `parseUrl` with query string that contain
 	const parsedUrl = queryString.parseUrl(url);
 	t.deepEqual(queryString.stringifyUrl(parsedUrl, {encode: false}), url);
 });
+
+test('stringify URL without sorting existing query params', t => {
+	t.deepEqual(queryString.stringifyUrl({url: 'https://foo.bar?C=3&A=1', query: {D: 4, B: 2}}, {sort: false}), 'https://foo.bar?C=3&A=1&D=4&B=2');
+});
+

--- a/test/stringify-url.js
+++ b/test/stringify-url.js
@@ -56,4 +56,3 @@ test('stringify URL from the result of `parseUrl` with query string that contain
 test('stringify URL without sorting existing query params', t => {
 	t.deepEqual(queryString.stringifyUrl({url: 'https://foo.bar?C=3&A=1', query: {D: 4, B: 2}}, {sort: false}), 'https://foo.bar?C=3&A=1&D=4&B=2');
 });
-


### PR DESCRIPTION
Fixes #264 .

Bug is fixed by passing the `options` object received in the `stringifyUrl` function to the internal use of `parse` function. Don't know if this could have other repercussions, but all tests passed that currently pass on master.