### PR TITLE
Add no-args case for stringify function type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -343,7 +343,7 @@ export interface StringifyOptions {
 Stringify an object into a query string and sort the keys.
 */
 export function stringify(
-	object: {[key: string]: any},
+	object?: {[key: string]: any},
 	options?: StringifyOptions
 ): string;
 


### PR DESCRIPTION
Hello!

I noticed that the `stringify` function's type declaration expects the first argument to always be passed. However, the actual code handles the falsy case (it returns an empty string).

I have some code which relies on that falsy case – ie. sometimes we effectively call `stringify(undefined)` – so I've updated the type declaration of `stringify` so this doesn't result in a type error.