### PR TITLE
Add tests to confirm existing number parsing behavior

### DIFF
--- a/test/parse.js
+++ b/test/parse.js
@@ -75,7 +75,7 @@ test('handle `+` correctly', t => {
 	t.deepEqual(queryString.parse('foo+faz=bar+baz++'), {'foo faz': 'bar baz  '});
 });
 
-test('handle number pasring correctly with math operators', t => {
+test('additional tests to clarify exisiting number parsing behavior', t => {
 	t.deepEqual(queryString.parse('192e11=bar'), {'192e11': 'bar'});
 	t.deepEqual(queryString.parse('bar=192e11'), {bar: '192e11'});
 });

--- a/test/parse.js
+++ b/test/parse.js
@@ -75,6 +75,11 @@ test('handle `+` correctly', t => {
 	t.deepEqual(queryString.parse('foo+faz=bar+baz++'), {'foo faz': 'bar baz  '});
 });
 
+test('handle number pasring correctly with math operators', t => {
+	t.deepEqual(queryString.parse('192e11=bar'), {'192e11': 'bar'});
+	t.deepEqual(queryString.parse('bar=192e11'), {bar: '192e11'});
+});
+
 test('handle `+` correctly when not decoding', t => {
 	t.deepEqual(queryString.parse('foo+faz=bar+baz++', {decode: false}), {'foo+faz': 'bar+baz++'});
 });

--- a/test/parse.js
+++ b/test/parse.js
@@ -75,7 +75,7 @@ test('handle `+` correctly', t => {
 	t.deepEqual(queryString.parse('foo+faz=bar+baz++'), {'foo faz': 'bar baz  '});
 });
 
-test('additional tests to clarify exisiting number parsing behavior', t => {
+test('parses numbers with exponential notation as string', t => {
 	t.deepEqual(queryString.parse('192e11=bar'), {'192e11': 'bar'});
 	t.deepEqual(queryString.parse('bar=192e11'), {bar: '192e11'});
 });


### PR DESCRIPTION
Added some extra tests to confirm the existing behavior of number parsing of `query-string`.
fixes #263 
// @sindresorhus 