### PR TITLE
When only receiving values with encoded array value, decode values

### DIFF
--- a/1.11.0
+++ b/1.11.0
@@ -1,3 +1,0 @@
-/usr/local/bin/webpack -> /usr/local/lib/node_modules/webpack/bin/webpack.js
-+ webpack@5.1.1
-updated 1 package in 3.303s

--- a/1.11.0
+++ b/1.11.0
@@ -1,0 +1,3 @@
+/usr/local/bin/webpack -> /usr/local/lib/node_modules/webpack/bin/webpack.js
++ webpack@5.1.1
+updated 1 package in 3.303s

--- a/index.js
+++ b/index.js
@@ -123,7 +123,9 @@ function parserForArrayFormat(options) {
 		case 'separator':
 			return (key, value, accumulator) => {
 				const isArray = typeof value === 'string' && value.split('').indexOf(options.arrayFormatSeparator) > -1;
-				const newValue = isArray ? value.split(options.arrayFormatSeparator).map(item => decode(item, options)) : value === null ? value : decode(value, options);
+				const isEncodedArray = (typeof value === 'string' && !isArray && decode(value, options).split('').indexOf(options.arrayFormatSeparator) > -1);
+				value = isEncodedArray ? decode(value, options) : value;
+				const newValue = isArray || isEncodedArray ? value.split(options.arrayFormatSeparator).map(item => decode(item, options)) : value === null ? value : decode(value, options);
 				accumulator[key] = newValue;
 			};
 

--- a/index.js
+++ b/index.js
@@ -122,8 +122,8 @@ function parserForArrayFormat(options) {
 		case 'comma':
 		case 'separator':
 			return (key, value, accumulator) => {
-				const isArray = typeof value === 'string' && value.split('').indexOf(options.arrayFormatSeparator) > -1;
-				const isEncodedArray = (typeof value === 'string' && !isArray && decode(value, options).split('').indexOf(options.arrayFormatSeparator) > -1);
+				const isArray = typeof value === 'string' && value.includes(options.arrayFormatSeparator);
+				const isEncodedArray = (typeof value === 'string' && !isArray && decode(value, options).includes(options.arrayFormatSeparator));
 				value = isEncodedArray ? decode(value, options) : value;
 				const newValue = isArray || isEncodedArray ? value.split(options.arrayFormatSeparator).map(item => decode(item, options)) : value === null ? value : decode(value, options);
 				accumulator[key] = newValue;

--- a/test/parse.js
+++ b/test/parse.js
@@ -323,7 +323,7 @@ test('value should not be decoded twice with `arrayFormat` option set as `separa
 });
 
 // See https://github.com/sindresorhus/query-string/issues/242
-test.failing('value separated by encoded comma will not be parsed as array with `arrayFormat` option set to `comma`', t => {
+test('value separated by encoded comma will not be parsed as array with `arrayFormat` option set to `comma`', t => {
 	t.deepEqual(queryString.parse('id=1%2C2%2C3', {arrayFormat: 'comma', parseNumbers: true}), {
 		id: [1, 2, 3]
 	});


### PR DESCRIPTION
Fixes https://github.com/sindresorhus/query-string/issues/242
Now all 99 tests pass (instead of one failing on purpose)
when pasting my url that used a custom array separator into slack, it was uri encoded, which broke things.
now in situations like that, the simple case will work, but allows more complicated cases to also still work.