### PR TITLE
Allow readonly `Stringifiable[]` in `StringifiableRecord`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -343,7 +343,7 @@ export type Stringifiable = string | boolean | number | null | undefined;
 
 export type StringifiableRecord = Record<
 	string,
-	Stringifiable | Stringifiable[]
+	Stringifiable | readonly Stringifiable[]
 >;
 
 /**


### PR DESCRIPTION
Since the first argument to `stringify` isn't mutated, readonly arrays should be allowed as record values. This is a backwards-compatible change, you'll still be able to pass a mutable array if you like.