### PR TITLE
Ignore ending ampersand when parsing

### DIFF
--- a/index.js
+++ b/index.js
@@ -244,6 +244,10 @@ function parse(query, options) {
 	}
 
 	for (const param of query.split('&')) {
+		if (param === '') {
+			continue;
+		}
+
 		let [key, value] = splitOnFirst(options.decode ? param.replace(/\+/g, ' ') : param, '=');
 
 		// Missing `=` should be `null`:

--- a/test/parse.js
+++ b/test/parse.js
@@ -15,6 +15,7 @@ test('query strings starting with a `&`', t => {
 
 test('query strings ending with a `&`', t => {
 	t.deepEqual(queryString.parse('foo=bar&'), {foo: 'bar'});
+	t.deepEqual(queryString.parse('foo=bar&&&'), {foo: 'bar'});
 });
 
 test('parse a query string', t => {

--- a/test/parse.js
+++ b/test/parse.js
@@ -13,6 +13,10 @@ test('query strings starting with a `&`', t => {
 	t.deepEqual(queryString.parse('&foo=bar&foo=baz'), {foo: ['bar', 'baz']});
 });
 
+test('query strings ending with a `&`', t => {
+	t.deepEqual(queryString.parse('foo=bar&'), {foo: 'bar'});
+});
+
 test('parse a query string', t => {
 	t.deepEqual(queryString.parse('foo=bar'), {foo: 'bar'});
 });


### PR DESCRIPTION
Hi there!

Sometimes query string has an extra ampersand in the end. I think it shouldn't be in the result. What do you think about it?

**String to parse**
`foo=bar&`

**Actual result**
`{ '': null, foo: 'bar' }`

**Expected result**
`{ foo: 'bar' }`