### PR TITLE
Stick to ES5

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,22 @@ const splitOnFirst = require('split-on-first');
 const filterObject = require('filter-obj');
 
 const isNullOrUndefined = value => value === null || value === undefined;
+// eslint-disable-next-line no-self-compare
+const numberIsNaN = input => typeof input === 'number' && input !== input;
+const assign = (...objects) => {
+	const merged = {};
+
+	for (let i = 0; i < objects.length; i++) {
+		const obj = objects[i];
+		for (const param in obj) {
+			if (Object.prototype.hasOwnProperty.call(obj, param)) {
+				merged[param] = obj[param];
+			}
+		}
+	}
+
+	return merged;
+};
 
 function encoderForArrayFormat(options) {
 	switch (options.arrayFormat) {
@@ -243,7 +259,7 @@ function extract(input) {
 }
 
 function parseValue(value, options) {
-	if (options.parseNumbers && !Number.isNaN(Number(value)) && (typeof value === 'string' && value.trim() !== '')) {
+	if (options.parseNumbers && !numberIsNaN(Number(value)) && (typeof value === 'string' && value.trim() !== '')) {
 		value = Number(value);
 	} else if (options.parseBooleans && value !== null && (value.toLowerCase() === 'true' || value.toLowerCase() === 'false')) {
 		value = value.toLowerCase() === 'true';
@@ -253,7 +269,7 @@ function parseValue(value, options) {
 }
 
 function parse(query, options) {
-	options = Object.assign({
+	options = assign({
 		decode: true,
 		sort: true,
 		arrayFormat: 'none',
@@ -328,7 +344,7 @@ exports.stringify = (object, options) => {
 		return '';
 	}
 
-	options = Object.assign({
+	options = assign({
 		encode: true,
 		strict: true,
 		arrayFormat: 'none',
@@ -384,13 +400,13 @@ exports.stringify = (object, options) => {
 };
 
 exports.parseUrl = (url, options) => {
-	options = Object.assign({
+	options = assign({
 		decode: true
 	}, options);
 
 	const [url_, hash] = splitOnFirst(url, '#');
 
-	return Object.assign(
+	return assign(
 		{
 			url: url_.split('?')[0] || '',
 			query: parse(extract(url), options)
@@ -400,7 +416,7 @@ exports.parseUrl = (url, options) => {
 };
 
 exports.stringifyUrl = (object, options) => {
-	options = Object.assign({
+	options = assign({
 		encode: true,
 		strict: true
 	}, options);
@@ -409,7 +425,7 @@ exports.stringifyUrl = (object, options) => {
 	const queryFromUrl = exports.extract(object.url);
 	const parsedQueryFromUrl = exports.parse(queryFromUrl, {sort: false});
 
-	const query = Object.assign(parsedQueryFromUrl, object.query);
+	const query = assign(parsedQueryFromUrl, object.query);
 	let queryString = exports.stringify(query, options);
 	if (queryString) {
 		queryString = `?${queryString}`;
@@ -424,7 +440,7 @@ exports.stringifyUrl = (object, options) => {
 };
 
 exports.pick = (input, filter, options) => {
-	options = Object.assign({
+	options = assign({
 		parseFragmentIdentifier: true
 	}, options);
 

--- a/index.js
+++ b/index.js
@@ -136,8 +136,8 @@ function parserForArrayFormat(options) {
 		case 'comma':
 		case 'separator':
 			return (key, value, accumulator) => {
-				const isArray = typeof value === 'string' && value.includes(options.arrayFormatSeparator);
-				const isEncodedArray = (typeof value === 'string' && !isArray && decode(value, options).includes(options.arrayFormatSeparator));
+				const isArray = typeof value === 'string' && value.indexOf(options.arrayFormatSeparator) !== -1;
+				const isEncodedArray = (typeof value === 'string' && !isArray && decode(value, options).indexOf(options.arrayFormatSeparator) !== -1);
 				value = isEncodedArray ? decode(value, options) : value;
 				const newValue = isArray || isEncodedArray ? value.split(options.arrayFormatSeparator).map(item => decode(item, options)) : value === null ? value : decode(value, options);
 				accumulator[key] = newValue;
@@ -288,7 +288,7 @@ function parse(query, options) {
 
 		// Missing `=` should be `null`:
 		// http://w3.org/TR/2012/WD-url-20120524/#collect-url-parameters
-		value = value === undefined ? null : ['comma', 'separator', 'bracket-separator'].includes(options.arrayFormat) ? value : decode(value, options);
+		value = value === undefined ? null : ['comma', 'separator', 'bracket-separator'].indexOf(options.arrayFormat) === -1 ? decode(value, options) : value;
 		formatter(decode(key, options), value, ret);
 	}
 
@@ -437,7 +437,7 @@ exports.pick = (input, filter, options) => {
 };
 
 exports.exclude = (input, filter, options) => {
-	const exclusionFilter = Array.isArray(filter) ? key => !filter.includes(key) : (key, value) => !filter(key, value);
+	const exclusionFilter = Array.isArray(filter) ? key => filter.indexOf(key) === -1 : (key, value) => !filter(key, value);
 
 	return exports.pick(input, exclusionFilter, options);
 };


### PR DESCRIPTION
We'd like to use this lib in an old environment which is only guaranteed to have ES5 support.

Things like rest arguments are fine because we can transpile those, but we can't transpile the changes in here.

WDYT?

Would be great if we don't need to maintain a fork for our use case.

Thanks