### PR TITLE
Fix type ParsedQuery to allow null in array

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -172,7 +172,7 @@ export interface ParseOptions {
 }
 
 export interface ParsedQuery<T = string> {
-	[key: string]: T | T[] | null;
+	[key: string]: T | null | Array<T | null>;
 }
 
 /**


### PR DESCRIPTION
The type `ParsedQuery` does not allow values to be `null` if the parameter occurs multiple times which clearly contradicts [this test case](https://github.com/sindresorhus/query-string/blob/v7.1.0/test/parse.js#L68).