### PR TITLE
Allow multi-charactor separators

### DIFF
--- a/index.js
+++ b/index.js
@@ -215,8 +215,8 @@ function parserForArrayFormat(options) {
 }
 
 function validateArrayFormatSeparator(value) {
-	if (typeof value !== 'string' || value.length !== 1) {
-		throw new TypeError('arrayFormatSeparator must be single character string');
+	if (typeof value !== 'string' || value.length === 0) {
+		throw new TypeError('arrayFormatSeparator must be a non-empty string');
 	}
 }
 

--- a/test/parse.js
+++ b/test/parse.js
@@ -160,6 +160,13 @@ test('query strings having pipe separated arrays and format option as `separator
 	}), {foo: ['bar', 'baz']});
 });
 
+test('query strings having multi-character seperated arrays and format option as `separator`', t => {
+	t.deepEqual(queryString.parse('foo=bar;;baz', {
+		arrayFormat: 'separator',
+		arrayFormatSeparator: ';;'
+	}), {foo: ['bar', 'baz']});
+});
+
 test('query strings having brackets arrays with null and format option as `bracket`', t => {
 	t.deepEqual(queryString.parse('bar[]&foo[]=a&foo[]&foo[]=', {
 		arrayFormat: 'bracket'
@@ -361,7 +368,7 @@ test('parseNumbers and parseBooleans can work with arrayFormat at the same time'
 });
 
 test('parse throws TypeError for invalid arrayFormatSeparator', t => {
-	t.throws(_ => queryString.parse('', {arrayFormatSeparator: ',,'}), {
+	t.throws(_ => queryString.parse('', {arrayFormatSeparator: ''}), {
 		instanceOf: TypeError
 	});
 	t.throws(_ => queryString.parse('', {arrayFormatSeparator: []}), {

--- a/test/stringify.js
+++ b/test/stringify.js
@@ -172,6 +172,15 @@ test('array stringify representation with array indexes and sparse array', t => 
 	t.is(queryString.stringify({bar: fixture}, {arrayFormat: 'index'}), 'bar[0]=one&bar[1]=two&bar[2]=three');
 });
 
+test('array stringify representation with multi-character separator', t => {
+	t.is(queryString.stringify({
+		bar: ['one', 'two']
+	}, {
+		arrayFormat: 'separator',
+		arrayFormatSeparator: ';;'
+	}), 'bar=one;;two');
+});
+
 test('array stringify representation with brackets and separators with empty array', t => {
 	t.is(queryString.stringify({
 		foo: null,
@@ -393,7 +402,7 @@ test('should ignore empty string when skipEmptyString is set for arrayFormat', t
 });
 
 test('stringify throws TypeError for invalid arrayFormatSeparator', t => {
-	t.throws(_ => queryString.stringify({}, {arrayFormatSeparator: ',,'}), {
+	t.throws(_ => queryString.stringify({}, {arrayFormatSeparator: ''}), {
 		instanceOf: TypeError
 	});
 	t.throws(_ => queryString.stringify({}, {arrayFormatSeparator: []}), {


### PR DESCRIPTION
There is nothing in the implementation that breaks with multi-character separators,
so the single character limitation is a bit arbitrary.

A system I work on uses `;;` as the separator in its HTTP API.