### PR TITLE
chore(deps): version up to 0.2.1 for decode-uri-component

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
 		"filter"
 	],
 	"dependencies": {
-		"decode-uri-component": "^0.2.0",
+		"decode-uri-component": "^0.2.1",
 		"filter-obj": "^1.1.0",
 		"split-on-first": "^1.0.0",
 		"strict-uri-encode": "^2.0.0"


### PR DESCRIPTION
It's fix [it](https://github.com/sindresorhus/query-string/issues/350).

Tests passed:
<img width="613" alt="Screenshot 2022-12-01 at 19 42 21" src="https://user-images.githubusercontent.com/11217819/205109927-f2bdb568-3076-4062-855e-0b58785a0146.png">

Fixes #350