### PR TITLE
fix: Encode fragmentIdentifier with encodeURI method not encodeURIComponent at stringifyUrl

### DIFF
--- a/index.js
+++ b/index.js
@@ -455,7 +455,9 @@ exports.stringifyUrl = (object, options) => {
 
 	let hash = getHash(object.url);
 	if (object.fragmentIdentifier) {
-		hash = `#${options[encodeFragmentIdentifier] ? encode(object.fragmentIdentifier, options) : object.fragmentIdentifier}`;
+		const urlObjectForFragmentEncode = new URL(url);
+		urlObjectForFragmentEncode.hash = object.fragmentIdentifier;
+		hash = options[encodeFragmentIdentifier] ? urlObjectForFragmentEncode.hash : `#${object.fragmentIdentifier}`;
 	}
 
 	return `${url}${queryString}${hash}`;

--- a/test/stringify-url.js
+++ b/test/stringify-url.js
@@ -26,6 +26,7 @@ test('stringify URL with fragment identifier', t => {
 	t.deepEqual(queryString.stringifyUrl({url: 'https://foo.bar/#abc', query: {}, fragmentIdentifier: 'top'}), 'https://foo.bar/#top');
 	t.deepEqual(queryString.stringifyUrl({url: 'https://foo.bar', query: {}}), 'https://foo.bar');
 	t.deepEqual(queryString.stringifyUrl({url: 'https://foo.bar', query: {}, fragmentIdentifier: 'foo bar'}), 'https://foo.bar#foo%20bar');
+	t.deepEqual(queryString.stringifyUrl({url: 'https://foo.bar/', query: {}, fragmentIdentifier: '/foo/bar'}), 'https://foo.bar/#/foo/bar');
 });
 
 test('skipEmptyString:: stringify URL with a query string', t => {


### PR DESCRIPTION
Fixes: #346 

FragmentIdentifier should be encoded with encodeURI method not encodeURIComponent method.
Also added test code about this fix.