### PR TITLE
Upgrade dependencies

### DIFF
--- a/base.js
+++ b/base.js
@@ -353,7 +353,13 @@ export function parse(query, options) {
 			continue;
 		}
 
-		let [key, value] = splitOnFirst(options.decode ? parameter.replace(/\+/g, ' ') : parameter, '=');
+		const param = options.decode ? parameter.replace(/\+/g, ' ') : parameter;
+
+		let [key, value] = splitOnFirst(param, '=');
+
+		if (key === undefined) {
+			key = param;
+		}
 
 		// Missing `=` should be `null`:
 		// http://w3.org/TR/2012/WD-url-20120524/#collect-url-parameters
@@ -454,7 +460,11 @@ export function parseUrl(url, options) {
 		...options,
 	};
 
-	const [url_, hash] = splitOnFirst(url, '#');
+	let [url_, hash] = splitOnFirst(url, '#');
+
+	if (url_ === undefined) {
+		url_ = url;
+	}
 
 	return {
 		url: url_?.split('?')?.[0] ?? '',

--- a/base.js
+++ b/base.js
@@ -353,12 +353,12 @@ export function parse(query, options) {
 			continue;
 		}
 
-		const param = options.decode ? parameter.replace(/\+/g, ' ') : parameter;
+		const parameter_ = options.decode ? parameter.replace(/\+/g, ' ') : parameter;
 
-		let [key, value] = splitOnFirst(param, '=');
+		let [key, value] = splitOnFirst(parameter_, '=');
 
 		if (key === undefined) {
-			key = param;
+			key = parameter_;
 		}
 
 		// Missing `=` should be `null`:

--- a/package.json
+++ b/package.json
@@ -45,9 +45,9 @@
 		"filter"
 	],
 	"dependencies": {
-		"decode-uri-component": "^0.2.2",
+		"decode-uri-component": "^0.4.1",
 		"filter-obj": "^5.1.0",
-		"split-on-first": "^1.0.0"
+		"split-on-first": "^3.0.0"
 	},
 	"devDependencies": {
 		"ava": "^5.1.0",


### PR DESCRIPTION
fixes #359 

This PR upgrades the dependencies of `decode-uri-component` and `split-on-first`. They both switched to ESM. I also included type definitions in the latest version of `decode-uri-component`.