### PR TITLE
feat: parseNumbers support includes & excludes options

### DIFF
--- a/base.d.ts
+++ b/base.d.ts
@@ -127,6 +127,7 @@ export type ParseOptions = {
 
 	/**
 	Parse the value as a number type instead of string type if it's a number.
+    Note: will always return a string if it exceeds the maximum safe integer in JavaScript
 
 	@default false
 
@@ -136,9 +137,15 @@ export type ParseOptions = {
 
 	queryString.parse('foo=1', {parseNumbers: true});
 	//=> {foo: 1}
+
+	queryString.parse('foo=1&bar=2', {parseNumbers: {includes: ['foo']}});
+	//=> {foo: 1, bar: '2'}
+
+	queryString.parse('foo=1&bar=2', {parseNumbers: {excludes: ['foo']}});
+	//=> {foo: '1', bar: 2}
 	```
 	*/
-	readonly parseNumbers?: boolean;
+	readonly parseNumbers?: boolean | {includes?: string[]; excludes?: string[]};
 
 	/**
 	Parse the value as a boolean type instead of string type if it's a boolean.

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
 		"deep-equal": "^2.1.0",
 		"fast-check": "^3.4.0",
 		"tsd": "^0.25.0",
-		"xo": "^0.53.1"
+		"xo": "^0.54.2"
 	},
 	"tsd": {
 		"compilerOptions": {

--- a/readme.md
+++ b/readme.md
@@ -197,7 +197,7 @@ Supports both `Function` as a custom sorting function or `false` to disable sort
 
 ##### parseNumbers
 
-Type: `boolean`\
+Type: `boolean | { includes?: string[], excludes?: string[] }`\
 Default: `false`
 
 ```js
@@ -205,9 +205,16 @@ import queryString from 'query-string';
 
 queryString.parse('foo=1', {parseNumbers: true});
 //=> {foo: 1}
-```
 
+queryString.parse('foo=1&bar=2', {parseNumbers: {includes: ['foo']}});
+//=> {foo: 1, bar: '2'}
+
+queryString.parse('foo=1&bar=2', {parseNumbers: {excludes: ['foo']}});
+//=> {foo: '1', bar: 2}
+```
 Parse the value as a number type instead of string type if it's a number.
+
+> Note: will always return a string if it exceeds the maximum safe integer in JavaScript
 
 ##### parseBooleans
 

--- a/test/parse.js
+++ b/test/parse.js
@@ -324,6 +324,31 @@ test('NaN value returns as string if option is set', t => {
 	t.deepEqual(queryString.parse('foo=   &bar=', {parseNumbers: true}), {foo: '   ', bar: ''});
 });
 
+test('exceed JavaScript\'s maximum safe integer value returns as string if option is set', t => {
+	// 9007199254740991 is Number.MAX_SAFE_INTEGER
+	t.deepEqual(queryString.parse('foo=9007199254740991', {parseNumbers: true}), {foo: Number.MAX_SAFE_INTEGER});
+	t.deepEqual(queryString.parse('foo=9007199254740992', {parseNumbers: true}), {foo: '9007199254740992'});
+	t.deepEqual(queryString.parse('foo=9007199254740992', {parseNumbers: {includes: ['foo']}}), {foo: '9007199254740992'});
+	t.deepEqual(queryString.parse('foo=9007199254740992', {parseNumbers: {excludes: ['foo']}}), {foo: '9007199254740992'});
+});
+
+test('only keys that match the includes configuration in parseNumbers will return number if parseNumbers.includes is set', t => {
+	t.deepEqual(queryString.parse('foo=1&bar=2', {parseNumbers: {includes: ['foo', 'bar']}}), {foo: 1, bar: 2});
+	t.deepEqual(queryString.parse('foo=1&bar=2', {parseNumbers: {includes: ['foo']}}), {foo: 1, bar: '2'});
+	t.deepEqual(queryString.parse('foo=null&bar=2', {parseNumbers: {includes: ['foo']}}), {foo: 'null', bar: '2'});
+	t.deepEqual(queryString.parse('foo=1&bar=2&baz=3', {parseNumbers: {includes: []}}), {foo: '1', bar: '2', baz: '3'});
+	t.deepEqual(queryString.parse('foo=1&bar=2&baz=3', {parseNumbers: {includes: ['foo'], excludes: ['baz']}}), {foo: 1, bar: '2', baz: '3'});
+	t.deepEqual(queryString.parse('foo=1&bar=2&baz=3', {parseNumbers: {includes: []}}), {foo: '1', bar: '2', baz: '3'});
+});
+
+test('only keys that does not match the excludes configuration in parseNumbers will return number if parseNumbers.excludes is set', t => {
+	t.deepEqual(queryString.parse('foo=1&bar=2', {parseNumbers: {excludes: ['foo', 'bar']}}), {foo: '1', bar: '2'});
+	t.deepEqual(queryString.parse('foo=1&bar=2', {parseNumbers: {excludes: ['foo']}}), {foo: '1', bar: 2});
+	t.deepEqual(queryString.parse('foo=1&bar=2', {parseNumbers: {excludes: []}}), {foo: 1, bar: 2});
+	t.deepEqual(queryString.parse('foo=1&bar=null', {parseNumbers: {excludes: ['foo']}}), {foo: '1', bar: 'null'});
+	t.deepEqual(queryString.parse('foo=1&bar=2&baz=3', {parseNumbers: {excludes: ['baz']}}), {foo: 1, bar: 2, baz: '3'});
+});
+
 test('parseNumbers works with arrayFormat', t => {
 	t.deepEqual(queryString.parse('foo[]=1&foo[]=2&foo[]=3&bar=1', {parseNumbers: true, arrayFormat: 'bracket'}), {foo: [1, 2, 3], bar: 1});
 	t.deepEqual(queryString.parse('foo=1,2,a', {parseNumbers: true, arrayFormat: 'comma'}), {foo: [1, 2, 'a']});


### PR DESCRIPTION
1. Added logic to return a string when the value exceeds the maximum safe JavaScript integer
2. Gives the user more flexibility to customize what to parse or not to parse when setting up parseNumbers.