### PR TITLE
recognize bigint as stringifiable

### DIFF
--- a/base.d.ts
+++ b/base.d.ts
@@ -412,7 +412,7 @@ export type StringifyOptions = {
 	readonly skipEmptyString?: boolean;
 };
 
-export type Stringifiable = string | boolean | number | null | undefined; // eslint-disable-line @typescript-eslint/ban-types
+export type Stringifiable = string | boolean | number | bigint | null | undefined; // eslint-disable-line @typescript-eslint/ban-types
 
 export type StringifiableRecord = Record<
 string,

--- a/base.js
+++ b/base.js
@@ -385,13 +385,7 @@ export function parse(query, options) {
 	// eslint-disable-next-line unicorn/no-array-reduce
 	return (options.sort === true ? Object.keys(returnValue).sort() : Object.keys(returnValue).sort(options.sort)).reduce((result, key) => {
 		const value = returnValue[key];
-		if (Boolean(value) && typeof value === 'object' && !Array.isArray(value)) {
-			// Sort object keys, not values
-			result[key] = keysSorter(value);
-		} else {
-			result[key] = value;
-		}
-
+		result[key] = Boolean(value) && typeof value === 'object' && !Array.isArray(value) ? keysSorter(value) : value;
 		return result;
 	}, Object.create(null));
 }

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
 		"deep-equal": "^2.1.0",
 		"fast-check": "^3.4.0",
 		"tsd": "^0.25.0",
-		"xo": "^0.53.1"
+		"xo": "^0.54.2"
 	},
 	"tsd": {
 		"compilerOptions": {

--- a/test/stringify.js
+++ b/test/stringify.js
@@ -14,6 +14,13 @@ test('different types', t => {
 	t.is(queryString.stringify(0), '');
 });
 
+test('primitive types', t => {
+	t.is(queryString.stringify({a: 'string'}), 'a=string');
+	t.is(queryString.stringify({a: true, b: false}), 'a=true&b=false');
+	t.is(queryString.stringify({a: 0, b: 1n}), 'a=0&b=1');
+	t.is(queryString.stringify({a: null, b: undefined}), 'a');
+});
+
 test('URI encode', t => {
 	t.is(queryString.stringify({'foo bar': 'baz faz'}), 'foo%20bar=baz%20faz');
 	t.is(queryString.stringify({'foo bar': 'baz\'faz'}), 'foo%20bar=baz%27faz');


### PR DESCRIPTION
This would be a nice feature to prevent some explicit `.toString()´ calls before passing an object to `stringify`.