### PR TITLE
FIX: types option - single array item parsing

### DIFF
--- a/base.js
+++ b/base.js
@@ -309,12 +309,20 @@ function parseValue(value, options, type) {
 		return type(value);
 	}
 
-	if (options.parseBooleans && value !== null && (value.toLowerCase() === 'true' || value.toLowerCase() === 'false')) {
-		return value.toLowerCase() === 'true';
+	if (type === 'string[]' && options.arrayFormat !== 'none' && typeof value === 'string') {
+		return [value];
+	}
+
+	if (type === 'number[]' && options.arrayFormat !== 'none' && !Number.isNaN(Number(value)) && (typeof value === 'string' && value.trim() !== '')) {
+		return [Number(value)];
 	}
 
 	if (type === 'number' && !Number.isNaN(Number(value)) && (typeof value === 'string' && value.trim() !== '')) {
 		return Number(value);
+	}
+
+	if (options.parseBooleans && value !== null && (value.toLowerCase() === 'true' || value.toLowerCase() === 'false')) {
+		return value.toLowerCase() === 'true';
 	}
 
 	if (options.parseNumbers && !Number.isNaN(Number(value)) && (typeof value === 'string' && value.trim() !== '')) {

--- a/test/parse.js
+++ b/test/parse.js
@@ -547,8 +547,7 @@ test('types option: all supported types work in conjunction with one another', t
 	});
 });
 
-// https://github.com/sindresorhus/query-string/issues/404
-test.failing('types option: single element with `{arrayFormat: "comma"}`', t => {
+test('types option: single element with `{arrayFormat: "comma"} and type: string[]`', t => {
 	t.deepEqual(queryString.parse('a=b', {
 		arrayFormat: 'comma',
 		types: {
@@ -556,5 +555,16 @@ test.failing('types option: single element with `{arrayFormat: "comma"}`', t => 
 		},
 	}), {
 		a: ['b'],
+	});
+});
+
+test('types option: single element with `{arrayFormat: "comma"}, and type: number[]`', t => {
+	t.deepEqual(queryString.parse('a=1', {
+		arrayFormat: 'comma',
+		types: {
+			a: 'number[]',
+		},
+	}), {
+		a: [1],
 	});
 });


### PR DESCRIPTION
Hey @sindresorhus , here's the fix https://github.com/sindresorhus/query-string/issues/404

I also realised this bug was affecting the `number[]` type as well, so have also fixed that too. 