### PR TITLE
FEAT: boolean type accepts an empty string as true

### DIFF
--- a/base.d.ts
+++ b/base.d.ts
@@ -286,7 +286,8 @@ export type ParseOptions = {
 	});
 	//=> {isAdmin: 'true', flagged: true, isOkay: false}
 	```
-	Note: The `'boolean'` type will also convert `'0'` and `'1'` string values to booleans.
+
+	Note: The `'boolean'` type also converts `'0'` and `'1'` to booleans, and treats valueless keys (e.g. `?flag`) as `true`.
 	*/
 	readonly types?: Record<
 	string,

--- a/base.js
+++ b/base.js
@@ -309,6 +309,10 @@ function parseValue(value, options, type) {
 		return type(value);
 	}
 
+	if (type === 'boolean' && value === null) {
+		return true;
+	}
+
 	if (type === 'boolean' && value !== null && (value.toLowerCase() === 'true' || value.toLowerCase() === 'false')) {
 		return value.toLowerCase() === 'true';
 	}

--- a/readme.md
+++ b/readme.md
@@ -217,7 +217,7 @@ queryString.parse('?isAdmin=true&flagged=true&isOkay=0', {
 //=> {isAdmin: 'true', flagged: true, isOkay: false}
 ```
 
-Note: The `'boolean'` type will also convert `'0'` and `'1'` string values to booleans.
+Note: The `'boolean'` type also converts `'0'` and `'1'` to booleans, and treats valueless keys (e.g. `?flag`) as `true`.
 
 - `'string'`: Parse `phoneNumber` as a string (overriding the `parseNumbers` option):
 

--- a/test/parse.js
+++ b/test/parse.js
@@ -592,3 +592,19 @@ test('types option: boolean type accepts 1 and 0 as boolean values', t => {
 		b: false,
 	});
 });
+
+test('types option: boolean type accepts an empty string as true', t => {
+	t.deepEqual(
+		queryString.parse('a&b', {
+			parsebooleans: false,
+			types: {
+				a: 'boolean',
+				b: 'boolean',
+			},
+		}),
+		{
+			a: true,
+			b: true,
+		},
+	);
+});


### PR DESCRIPTION
Implemented the request for supporting null values as booleans from this comment https://github.com/sindresorhus/query-string/pull/407#issuecomment-2915480810
